### PR TITLE
Fix NPE on concurrent RecordHeader.key() access

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
+++ b/clients/src/main/java/org/apache/kafka/clients/admin/OffsetSpec.java
@@ -25,6 +25,7 @@ public class OffsetSpec {
 
     public static class EarliestSpec extends OffsetSpec { }
     public static class LatestSpec extends OffsetSpec { }
+    public static class MaxTimestampSpec extends OffsetSpec { }
     public static class TimestampSpec extends OffsetSpec {
         private final long timestamp;
 
@@ -58,6 +59,15 @@ public class OffsetSpec {
      */
     public static OffsetSpec forTimestamp(long timestamp) {
         return new TimestampSpec(timestamp);
+    }
+
+    /**
+     * Used to retrieve the offset with the largest timestamp of a partition
+     * as message timestamps can be specified client side this may not match
+     * the log end offset returned by LatestSpec
+     */
+    public static OffsetSpec maxTimestamp() {
+        return new MaxTimestampSpec();
     }
 
 }

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/AbstractCoordinator.java
@@ -1119,12 +1119,14 @@ public abstract class AbstractCoordinator implements Closeable {
             } else if (error == Errors.REBALANCE_IN_PROGRESS) {
                 // since we may be sending the request during rebalance, we should check
                 // this case and ignore the REBALANCE_IN_PROGRESS error
-                if (state == MemberState.STABLE) {
-                    requestRejoin("group is already rebalancing");
-                    future.raise(error);
-                } else {
-                    log.debug("Ignoring heartbeat response with error {} during {} state", error, state);
-                    future.complete(null);
+                synchronized (AbstractCoordinator.this) {
+                    if (state == MemberState.STABLE) {
+                        requestRejoin("group is already rebalancing");
+                        future.raise(error);
+                    } else {
+                        log.debug("Ignoring heartbeat response with error {} during {} state", error, state);
+                        future.complete(null);
+                    }
                 }
             } else if (error == Errors.ILLEGAL_GENERATION ||
                        error == Errors.UNKNOWN_MEMBER_ID ||

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java
@@ -1216,13 +1216,17 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
                             if (generationUnchanged()) {
                                 future.raise(error);
                             } else {
-                                if (ConsumerCoordinator.this.state == MemberState.PREPARING_REBALANCE) {
-                                    future.raise(new RebalanceInProgressException("Offset commit cannot be completed since the " +
-                                        "consumer member's old generation is fenced by its group instance id, it is possible that " +
-                                        "this consumer has already participated another rebalance and got a new generation"));
-                                } else {
-                                    future.raise(new CommitFailedException());
+                                KafkaException exception;
+                                synchronized (ConsumerCoordinator.this) {
+                                    if (ConsumerCoordinator.this.state == MemberState.PREPARING_REBALANCE) {
+                                        exception = new RebalanceInProgressException("Offset commit cannot be completed since the " +
+                                            "consumer member's old generation is fenced by its group instance id, it is possible that " +
+                                            "this consumer has already participated another rebalance and got a new generation");
+                                    } else {
+                                        exception = new CommitFailedException();
+                                    }
                                 }
+                                future.raise(exception);
                             }
                             return;
                         } else if (error == Errors.REBALANCE_IN_PROGRESS) {
@@ -1245,14 +1249,18 @@ public final class ConsumerCoordinator extends AbstractCoordinator {
 
                             // only need to reset generation and re-join group if generation has not changed or we are not in rebalancing;
                             // otherwise only raise rebalance-in-progress error
-                            if (!generationUnchanged() && ConsumerCoordinator.this.state == MemberState.PREPARING_REBALANCE) {
-                                future.raise(new RebalanceInProgressException("Offset commit cannot be completed since the " +
-                                    "consumer member's generation is already stale, meaning it has already participated another rebalance and " +
-                                    "got a new generation. You can try completing the rebalance by calling poll() and then retry commit again"));
-                            } else {
-                                resetGenerationOnResponseError(ApiKeys.OFFSET_COMMIT, error);
-                                future.raise(new CommitFailedException());
+                            KafkaException exception;
+                            synchronized (ConsumerCoordinator.this) {
+                                if (!generationUnchanged() && ConsumerCoordinator.this.state == MemberState.PREPARING_REBALANCE) {
+                                    exception = new RebalanceInProgressException("Offset commit cannot be completed since the " +
+                                        "consumer member's generation is already stale, meaning it has already participated another rebalance and " +
+                                        "got a new generation. You can try completing the rebalance by calling poll() and then retry commit again");
+                                } else {
+                                    resetGenerationOnResponseError(ApiKeys.OFFSET_COMMIT, error);
+                                    exception = new CommitFailedException();
+                                }
                             }
+                            future.raise(exception);
                             return;
                         } else {
                             future.raise(new KafkaException("Unexpected error in commit: " + error.message()));

--- a/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
+++ b/clients/src/main/java/org/apache/kafka/clients/consumer/internals/Fetcher.java
@@ -978,7 +978,7 @@ public class Fetcher<K, V> implements Closeable {
                                                                   final Map<TopicPartition, ListOffsetsPartition> timestampsToSearch,
                                                                   boolean requireTimestamp) {
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(requireTimestamp, isolationLevel)
+                .forConsumer(requireTimestamp, isolationLevel, false)
                 .setTargetTimes(ListOffsetsRequest.toListOffsetsTopics(timestampsToSearch));
 
         log.debug("Sending ListOffsetRequest {} to broker {}", builder, node);

--- a/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeader.java
+++ b/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeader.java
@@ -40,7 +40,7 @@ public class RecordHeader implements Header {
         this.valueBuffer = valueBuffer;
     }
     
-    public String key() {
+    public synchronized String key() {
         if (key == null) {
             key = Utils.utf8(keyBuffer, keyBuffer.remaining());
             keyBuffer = null;
@@ -48,7 +48,7 @@ public class RecordHeader implements Header {
         return key;
     }
 
-    public byte[] value() {
+    public synchronized byte[] value() {
         if (value == null && valueBuffer != null) {
             value = Utils.toArray(valueBuffer);
             valueBuffer = null;

--- a/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/ApiKeys.java
@@ -96,7 +96,7 @@ public enum ApiKeys {
     VOTE(ApiMessageType.VOTE, true, RecordBatch.MAGIC_VALUE_V0, false),
     BEGIN_QUORUM_EPOCH(ApiMessageType.BEGIN_QUORUM_EPOCH, true, RecordBatch.MAGIC_VALUE_V0, false),
     END_QUORUM_EPOCH(ApiMessageType.END_QUORUM_EPOCH, true, RecordBatch.MAGIC_VALUE_V0, false),
-    DESCRIBE_QUORUM(ApiMessageType.DESCRIBE_QUORUM, true, RecordBatch.MAGIC_VALUE_V0, false),
+    DESCRIBE_QUORUM(ApiMessageType.DESCRIBE_QUORUM, true, RecordBatch.MAGIC_VALUE_V0, true),
     ALTER_ISR(ApiMessageType.ALTER_ISR, true),
     UPDATE_FEATURES(ApiMessageType.UPDATE_FEATURES, false, true),
     ENVELOPE(ApiMessageType.ENVELOPE, true, RecordBatch.MAGIC_VALUE_V0, false),

--- a/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/ListOffsetsRequest.java
@@ -40,6 +40,7 @@ import org.apache.kafka.common.protocol.Errors;
 public class ListOffsetsRequest extends AbstractRequest {
     public static final long EARLIEST_TIMESTAMP = -2L;
     public static final long LATEST_TIMESTAMP = -1L;
+    public static final long MAX_TIMESTAMP = -3L;
 
     public static final int CONSUMER_REPLICA_ID = -1;
     public static final int DEBUGGING_REPLICA_ID = -2;
@@ -54,9 +55,11 @@ public class ListOffsetsRequest extends AbstractRequest {
             return new Builder((short) 0, allowedVersion, replicaId, IsolationLevel.READ_UNCOMMITTED);
         }
 
-        public static Builder forConsumer(boolean requireTimestamp, IsolationLevel isolationLevel) {
+        public static Builder forConsumer(boolean requireTimestamp, IsolationLevel isolationLevel, boolean requireMaxTimestamp) {
             short minVersion = 0;
-            if (isolationLevel == IsolationLevel.READ_COMMITTED)
+            if (requireMaxTimestamp)
+                minVersion = 7;
+            else if (isolationLevel == IsolationLevel.READ_COMMITTED)
                 minVersion = 2;
             else if (requireTimestamp)
                 minVersion = 1;

--- a/clients/src/main/resources/common/message/ListOffsetsRequest.json
+++ b/clients/src/main/resources/common/message/ListOffsetsRequest.json
@@ -30,7 +30,9 @@
   // Version 5 is the same as version 4.
   //
   // Version 6 enables flexible versions.
-  "validVersions": "0-6",
+  //
+  // Version 7 enables listing offsets by max timestamp (KIP-734).
+  "validVersions": "0-7",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "ReplicaId", "type": "int32", "versions": "0+", "entityType": "brokerId",

--- a/clients/src/main/resources/common/message/ListOffsetsResponse.json
+++ b/clients/src/main/resources/common/message/ListOffsetsResponse.json
@@ -29,7 +29,9 @@
   // Version 5 adds a new error code, OFFSET_NOT_AVAILABLE.
   //
   // Version 6 enables flexible versions.
-  "validVersions": "0-6",
+  //
+  // Version 7 is the same as version 6 (KIP-734).
+  "validVersions": "0-7",
   "flexibleVersions": "6+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "2+", "ignorable": true,

--- a/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/consumer/internals/ConsumerProtocolTest.java
@@ -58,7 +58,7 @@ public class ConsumerProtocolTest {
             ByteBuffer buffer = ConsumerProtocol.serializeSubscription(subscription, version);
             Subscription parsedSubscription = ConsumerProtocol.deserializeSubscription(buffer);
 
-            assertEquals(subscription.topics(), parsedSubscription.topics());
+            assertEquals(toSet(subscription.topics()), toSet(parsedSubscription.topics()));
             assertEquals(subscription.userData(), parsedSubscription.userData());
             assertFalse(parsedSubscription.groupInstanceId().isPresent());
 
@@ -75,7 +75,7 @@ public class ConsumerProtocolTest {
         Subscription subscription = new Subscription(Arrays.asList("foo", "bar"), ByteBuffer.wrap(new byte[0]));
         ByteBuffer buffer = ConsumerProtocol.serializeSubscription(subscription);
         Subscription parsedSubscription = ConsumerProtocol.deserializeSubscription(buffer);
-        assertEquals(subscription.topics(), parsedSubscription.topics());
+        assertEquals(toSet(subscription.topics()), toSet(parsedSubscription.topics()));
         assertEquals(0, parsedSubscription.userData().limit());
         assertFalse(parsedSubscription.groupInstanceId().isPresent());
     }
@@ -87,7 +87,7 @@ public class ConsumerProtocolTest {
 
         Subscription parsedSubscription = ConsumerProtocol.deserializeSubscription(buffer);
         parsedSubscription.setGroupInstanceId(groupInstanceId);
-        assertEquals(subscription.topics(), parsedSubscription.topics());
+        assertEquals(toSet(subscription.topics()), toSet(parsedSubscription.topics()));
         assertEquals(0, parsedSubscription.userData().limit());
         assertEquals(groupInstanceId, parsedSubscription.groupInstanceId());
     }
@@ -97,8 +97,32 @@ public class ConsumerProtocolTest {
         Subscription subscription = new Subscription(Arrays.asList("foo", "bar"), null);
         ByteBuffer buffer = ConsumerProtocol.serializeSubscription(subscription);
         Subscription parsedSubscription = ConsumerProtocol.deserializeSubscription(buffer);
-        assertEquals(subscription.topics(), parsedSubscription.topics());
+        assertEquals(toSet(subscription.topics()), toSet(parsedSubscription.topics()));
         assertNull(parsedSubscription.userData());
+    }
+
+    @Test
+    public void serializeSubscriptionShouldOrderTopics() {
+        assertEquals(
+            ConsumerProtocol.serializeSubscription(
+                new Subscription(Arrays.asList("foo", "bar"), null, Arrays.asList(tp1, tp2))
+            ),
+            ConsumerProtocol.serializeSubscription(
+                new Subscription(Arrays.asList("bar", "foo"), null, Arrays.asList(tp1, tp2))
+            )
+        );
+    }
+
+    @Test
+    public void serializeSubscriptionShouldOrderOwnedPartitions() {
+        assertEquals(
+            ConsumerProtocol.serializeSubscription(
+                new Subscription(Arrays.asList("foo", "bar"), null, Arrays.asList(tp1, tp2))
+            ),
+            ConsumerProtocol.serializeSubscription(
+                new Subscription(Arrays.asList("foo", "bar"), null, Arrays.asList(tp2, tp1))
+            )
+        );
     }
 
     @Test
@@ -106,7 +130,7 @@ public class ConsumerProtocolTest {
         Subscription subscription = new Subscription(Arrays.asList("foo", "bar"), null);
         ByteBuffer buffer = ConsumerProtocol.serializeSubscription(subscription, (short) 0);
         Subscription parsedSubscription = ConsumerProtocol.deserializeSubscription(buffer);
-        assertEquals(parsedSubscription.topics(), parsedSubscription.topics());
+        assertEquals(toSet(parsedSubscription.topics()), toSet(parsedSubscription.topics()));
         assertNull(parsedSubscription.userData());
         assertTrue(parsedSubscription.ownedPartitions().isEmpty());
     }
@@ -118,7 +142,7 @@ public class ConsumerProtocolTest {
         // ignore the version assuming it is the old byte code, as it will blindly deserialize as V0
         ConsumerProtocol.deserializeVersion(buffer);
         Subscription parsedSubscription = ConsumerProtocol.deserializeSubscription(buffer, (short) 0);
-        assertEquals(subscription.topics(), parsedSubscription.topics());
+        assertEquals(toSet(subscription.topics()), toSet(parsedSubscription.topics()));
         assertNull(parsedSubscription.userData());
         assertTrue(parsedSubscription.ownedPartitions().isEmpty());
         assertFalse(parsedSubscription.groupInstanceId().isPresent());
@@ -156,8 +180,8 @@ public class ConsumerProtocolTest {
 
         Subscription subscription = ConsumerProtocol.deserializeSubscription(buffer);
         subscription.setGroupInstanceId(groupInstanceId);
-        assertEquals(Collections.singletonList("topic"), subscription.topics());
-        assertEquals(Collections.singletonList(tp2), subscription.ownedPartitions());
+        assertEquals(Collections.singleton("topic"), toSet(subscription.topics()));
+        assertEquals(Collections.singleton(tp2), toSet(subscription.ownedPartitions()));
         assertEquals(groupInstanceId, subscription.groupInstanceId());
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeaderConcurrentTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/header/internals/RecordHeaderConcurrentTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.header.internals;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RecordHeaderConcurrentTest {
+
+    private static final int ITERATIONS = 100_000;
+
+    private final byte[] keyBytes = "key".getBytes(StandardCharsets.UTF_8);
+    private final byte[] valueBytes = "value".getBytes(StandardCharsets.UTF_8);
+    private final ByteBuffer keyBuffer = ByteBuffer.wrap(keyBytes);
+    private final ByteBuffer valueBuffer = ByteBuffer.wrap(valueBytes);
+
+    private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    @AfterAll
+    public static void shutdownExecutor() {
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testConcurrentKeyInit() throws ExecutionException, InterruptedException {
+        for (int i = 0; i < ITERATIONS; i++) {
+            RecordHeader header = new RecordHeader(keyBuffer, valueBuffer);
+            Future<String> future = executorService.submit(header::key);
+            assertEquals("key", header.key());
+            assertEquals("key", future.get());
+        }
+    }
+
+    @Test
+    public void testConcurrentValueInit() throws ExecutionException, InterruptedException {
+        for (int i = 0; i < ITERATIONS; i++) {
+            RecordHeader header = new RecordHeader(keyBuffer, valueBuffer);
+            Future<byte[]> future = executorService.submit(header::value);
+            assertArrayEquals(valueBytes, header.value());
+            assertArrayEquals(valueBytes, future.get());
+        }
+    }
+
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/ListOffsetsRequestTest.java
@@ -67,7 +67,7 @@ public class ListOffsetsRequestTest {
                                 new ListOffsetsPartition()
                                     .setPartitionIndex(0))));
             ListOffsetsRequest request = ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_COMMITTED)
+                    .forConsumer(true, IsolationLevel.READ_COMMITTED, false)
                     .setTargetTimes(topics)
                     .build(version);
             ListOffsetsResponse response = (ListOffsetsResponse) request.getErrorResponse(0, Errors.NOT_LEADER_OR_FOLLOWER.exception());
@@ -100,7 +100,7 @@ public class ListOffsetsRequestTest {
                             new ListOffsetsPartition()
                                 .setPartitionIndex(0))));
         ListOffsetsRequest request = ListOffsetsRequest.Builder
-                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
                 .setTargetTimes(topics)
                 .build((short) 0);
         ListOffsetsResponse response = (ListOffsetsResponse) request.getErrorResponse(0, Errors.NOT_LEADER_OR_FOLLOWER.exception());

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1454,7 +1454,7 @@ public class RequestResponseTest {
                             .setMaxNumOffsets(10)
                             .setCurrentLeaderEpoch(5)));
             return ListOffsetsRequest.Builder
-                    .forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
+                    .forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false)
                     .setTargetTimes(Collections.singletonList(topic))
                     .build((short) version);
         } else if (version == 1) {
@@ -1465,7 +1465,7 @@ public class RequestResponseTest {
                             .setTimestamp(1000000L)
                             .setCurrentLeaderEpoch(5)));
             return ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+                    .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
                     .setTargetTimes(Collections.singletonList(topic))
                     .build((short) version);
         } else if (version >= 2 && version <= LIST_OFFSETS.latestVersion()) {
@@ -1478,7 +1478,7 @@ public class RequestResponseTest {
                     .setName("test")
                     .setPartitions(Arrays.asList(partition));
             return ListOffsetsRequest.Builder
-                    .forConsumer(true, IsolationLevel.READ_COMMITTED)
+                    .forConsumer(true, IsolationLevel.READ_COMMITTED, false)
                     .setTargetTimes(Collections.singletonList(topic))
                     .build((short) version);
         } else {

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -114,7 +114,9 @@ object ApiVersion {
     // Introduced topic IDs to LeaderAndIsr and UpdateMetadata requests/responses (KIP-516)
     KAFKA_2_8_IV1,
     // Introduce AllocateProducerIds (KIP-730)
-    KAFKA_3_0_IV0
+    KAFKA_3_0_IV0,
+    // Introduce ListOffsets V7 which supports listing offsets by max timestamp (KIP-734)
+    KAFKA_3_0_IV1
   )
 
   // Map keys are the union of the short and full versions
@@ -456,6 +458,13 @@ case object KAFKA_3_0_IV0 extends DefaultApiVersion {
   val subVersion = "IV0"
   val recordVersion = RecordVersion.V2
   val id: Int = 33
+}
+
+case object KAFKA_3_0_IV1 extends DefaultApiVersion {
+  val shortVersion: String = "3.0"
+  val subVersion = "IV1"
+  val recordVersion = RecordVersion.V2
+  val id: Int = 34
 }
 
 object ApiVersionValidator extends Validator {

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1338,6 +1338,16 @@ class Log(@volatile private var _dir: File,
         val latestEpochOpt = leaderEpochCache.flatMap(_.latestEpoch).map(_.asInstanceOf[Integer])
         val epochOptional = Optional.ofNullable(latestEpochOpt.orNull)
         Some(new TimestampAndOffset(RecordBatch.NO_TIMESTAMP, logEndOffset, epochOptional))
+      } else if (targetTimestamp == ListOffsetsRequest.MAX_TIMESTAMP) {
+        // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
+        // constant time access while being safe to use with concurrent collections unlike `toArray`.
+        val segmentsCopy = logSegments.toBuffer
+        val latestTimestampSegment = segmentsCopy.maxBy(_.maxTimestampSoFar)
+        val latestEpochOpt = leaderEpochCache.flatMap(_.latestEpoch).map(_.asInstanceOf[Integer])
+        val epochOptional = Optional.ofNullable(latestEpochOpt.orNull)
+        Some(new TimestampAndOffset(latestTimestampSegment.maxTimestampSoFar,
+          latestTimestampSegment.offsetOfMaxTimestampSoFar,
+          epochOptional))
       } else {
         // Cache to avoid race conditions. `toBuffer` is faster than most alternatives and provides
         // constant time access while being safe to use with concurrent collections unlike `toArray`.

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -141,6 +141,16 @@ class KafkaApis(val requestChannel: RequestChannel,
     metadataSupport.maybeForward(request, handler, responseCallback)
   }
 
+  private def forwardToControllerOrFail(
+    request: RequestChannel.Request
+  ): Unit = {
+    def errorHandler(request: RequestChannel.Request): Unit = {
+      throw new IllegalStateException(s"Unable to forward $request to the controller")
+    }
+
+    maybeForwardToController(request, errorHandler)
+  }
+
   /**
    * Top-level method that handles all requests and multiplexes to the right api
    */
@@ -217,6 +227,7 @@ class KafkaApis(val requestChannel: RequestChannel,
         case ApiKeys.DESCRIBE_TRANSACTIONS => handleDescribeTransactionsRequest(request)
         case ApiKeys.LIST_TRANSACTIONS => handleListTransactionsRequest(request)
         case ApiKeys.ALLOCATE_PRODUCER_IDS => maybeForwardToController(request, handleAllocateProducerIdsRequest)
+        case ApiKeys.DESCRIBE_QUORUM => forwardToControllerOrFail(request)
         case _ => throw new IllegalStateException(s"No handler for request api key ${request.header.apiKey}")
       }
     } catch {

--- a/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaFetcherThread.scala
@@ -94,7 +94,8 @@ class ReplicaFetcherThread(name: String,
 
   // Visible for testing
   private[server] val listOffsetRequestVersion: Short =
-    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_8_IV0) 6
+    if (brokerConfig.interBrokerProtocolVersion >= KAFKA_3_0_IV1) 7
+    else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_8_IV0) 6
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_2_IV1) 5
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_1_IV1) 4
     else if (brokerConfig.interBrokerProtocolVersion >= KAFKA_2_0_IV1) 3

--- a/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
+++ b/core/src/test/java/kafka/test/ClusterTestExtensionsTest.java
@@ -86,7 +86,7 @@ public class ClusterTestExtensionsTest {
             @ClusterConfigProperty(key = "foo", value = "bar"),
             @ClusterConfigProperty(key = "spam", value = "eggs")
         }),
-        @ClusterTest(name = "cluster-tests-2", clusterType = Type.RAFT, serverProperties = {
+        @ClusterTest(name = "cluster-tests-2", clusterType = Type.KRAFT, serverProperties = {
             @ClusterConfigProperty(key = "foo", value = "baz"),
             @ClusterConfigProperty(key = "spam", value = "eggz")
         })

--- a/core/src/test/java/kafka/test/annotation/Type.java
+++ b/core/src/test/java/kafka/test/annotation/Type.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
  * The type of cluster config being requested. Used by {@link kafka.test.ClusterConfig} and the test annotations.
  */
 public enum Type {
-    RAFT {
+    KRAFT {
         @Override
         public void invocationContexts(ClusterConfig config, Consumer<TestTemplateInvocationContext> invocationConsumer) {
             invocationConsumer.accept(new RaftClusterInvocationContext(config.copyOf()));

--- a/core/src/test/scala/integration/kafka/admin/ListOffsetsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/admin/ListOffsetsIntegrationTest.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration.kafka.admin
+
+import kafka.integration.KafkaServerTestHarness
+import kafka.server.KafkaConfig
+import kafka.utils.TestUtils
+import org.apache.kafka.clients.admin._
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.utils.Utils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+
+import scala.collection.{Map, Seq}
+import scala.jdk.CollectionConverters._
+
+class ListOffsetsIntegrationTest extends KafkaServerTestHarness {
+
+  val topicName = "foo"
+  var adminClient: Admin = null
+
+  @BeforeEach
+  override def setUp(): Unit = {
+    super.setUp()
+    createTopic(topicName, 1, 1.toShort)
+    produceMessages()
+    adminClient = Admin.create(Map[String, Object](
+      AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> brokerList
+    ).asJava)
+  }
+
+  @AfterEach
+  override def tearDown(): Unit = {
+    Utils.closeQuietly(adminClient, "ListOffsetsAdminClient")
+    super.tearDown()
+  }
+
+  @Test
+  def testEarliestOffset(): Unit = {
+    val earliestOffset = runFetchOffsets(adminClient, OffsetSpec.earliest())
+    assertEquals(0, earliestOffset.offset())
+  }
+
+  @Test
+  def testLatestOffset(): Unit = {
+    val latestOffset = runFetchOffsets(adminClient, OffsetSpec.latest())
+    assertEquals(3, latestOffset.offset())
+  }
+
+  @Test
+  def testMaxTimestampOffset(): Unit = {
+    val maxTimestampOffset = runFetchOffsets(adminClient, OffsetSpec.maxTimestamp())
+    assertEquals(1, maxTimestampOffset.offset())
+  }
+
+  private def runFetchOffsets(adminClient: Admin,
+                              offsetSpec: OffsetSpec): ListOffsetsResult.ListOffsetsResultInfo = {
+    val tp = new TopicPartition(topicName, 0)
+    adminClient.listOffsets(Map(
+      tp -> offsetSpec
+    ).asJava, new ListOffsetsOptions()).all().get().get(tp)
+  }
+
+  def produceMessages(): Unit = {
+    val records = Seq(
+      new ProducerRecord[Array[Byte], Array[Byte]](topicName, 0, 100L,
+        null, new Array[Byte](10000)),
+      new ProducerRecord[Array[Byte], Array[Byte]](topicName, 0, 999L,
+        null, new Array[Byte](10000)),
+      new ProducerRecord[Array[Byte], Array[Byte]](topicName, 0, 200L,
+        null, new Array[Byte](10000)),
+    )
+    TestUtils.produceMessages(servers, records, -1)
+  }
+
+  def generateConfigs: Seq[KafkaConfig] =
+    TestUtils.createBrokerConfigs(1, zkConnect).map(KafkaConfig.fromProps)
+}
+

--- a/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/api/AuthorizerIntegrationTest.scala
@@ -354,7 +354,7 @@ class AuthorizerIntegrationTest extends BaseRequestTest {
   }
 
   private def createListOffsetsRequest = {
-    requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED).setTargetTimes(
+    requests.ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false).setTargetTimes(
       List(new ListOffsetsTopic()
         .setName(tp.topic)
         .setPartitions(List(new ListOffsetsPartition()

--- a/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
+++ b/core/src/test/scala/integration/kafka/coordinator/transaction/ProducerIdsIntegrationTest.scala
@@ -45,7 +45,7 @@ class ProducerIdsIntegrationTest {
   @ClusterTests(Array(
     new ClusterTest(clusterType = Type.ZK, brokers = 3, ibp = "2.8"),
     new ClusterTest(clusterType = Type.ZK, brokers = 3, ibp = "3.0-IV0"),
-    new ClusterTest(clusterType = Type.RAFT, brokers = 3, ibp = "3.0-IV0")
+    new ClusterTest(clusterType = Type.KRAFT, brokers = 3, ibp = "3.0-IV0")
   ))
   def testUniqueProducerIds(clusterInstance: ClusterInstance): Unit = {
     verifyUniqueIds(clusterInstance)

--- a/core/src/test/scala/kafka/server/metadata/MockConfigRepository.scala
+++ b/core/src/test/scala/kafka/server/metadata/MockConfigRepository.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.metadata;
+
+import java.util
+import java.util.Properties
+
+import org.apache.kafka.common.config.ConfigResource
+import org.apache.kafka.common.config.ConfigResource.Type.TOPIC
+
+object MockConfigRepository {
+  def forTopic(topic: String, key: String, value: String): MockConfigRepository = {
+    val properties = new Properties()
+    properties.put(key, value)
+    forTopic(topic, properties)
+  }
+
+  def forTopic(topic:String, properties: Properties): MockConfigRepository = {
+    val repository = new MockConfigRepository()
+    repository.configs.put(new ConfigResource(TOPIC, topic), properties)
+    repository
+  }
+}
+
+class MockConfigRepository extends ConfigRepository {
+  val configs = new util.HashMap[ConfigResource, Properties]()
+
+  override def config(configResource: ConfigResource): Properties = configs.synchronized {
+    configs.getOrDefault(configResource, new Properties())
+  }
+
+  def setConfig(configResource: ConfigResource, key: String, value: String): Unit = configs.synchronized {
+    val properties = configs.getOrDefault(configResource, new Properties())
+    val newProperties = new Properties()
+    newProperties.putAll(properties)
+    if (value == null) {
+      newProperties.remove(key)
+    } else {
+      newProperties.put(key, value)
+    }
+    configs.put(configResource, newProperties)
+  }
+
+  def setTopicConfig(topicName: String, key: String, value: String): Unit = configs.synchronized {
+    setConfig(new ConfigResource(TOPIC, topicName), key, value)
+  }
+}

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -18,11 +18,12 @@ package kafka.cluster
 
 import java.io.File
 import java.util.Properties
+
 import kafka.api.ApiVersion
 import kafka.log.{CleanerConfig, LogConfig, LogManager}
 import kafka.server.{Defaults, MetadataCache}
 import kafka.server.checkpoints.OffsetCheckpoints
-import kafka.server.metadata.CachedConfigRepository
+import kafka.server.metadata.MockConfigRepository
 import kafka.utils.TestUtils.{MockAlterIsrManager, MockIsrChangeListener}
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.TopicPartition
@@ -47,7 +48,7 @@ class AbstractPartitionTest {
   var alterIsrManager: MockAlterIsrManager = _
   var isrChangeListener: MockIsrChangeListener = _
   var logConfig: LogConfig = _
-  var configRepository: CachedConfigRepository = _
+  var configRepository: MockConfigRepository = _
   val delayedOperations: DelayedOperations = mock(classOf[DelayedOperations])
   val metadataCache: MetadataCache = mock(classOf[MetadataCache])
   val offsetCheckpoints: OffsetCheckpoints = mock(classOf[OffsetCheckpoints])
@@ -59,7 +60,7 @@ class AbstractPartitionTest {
 
     val logProps = createLogProperties(Map.empty)
     logConfig = LogConfig(logProps)
-    configRepository = TestUtils.createConfigRepository(topicPartition.topic(), logProps)
+    configRepository = MockConfigRepository.forTopic(topicPartition.topic(), logProps)
 
     tmpDir = TestUtils.tempDir()
     logDir1 = TestUtils.randomPartitionLogDir(tmpDir)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -20,11 +20,13 @@ package kafka.cluster
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent._
+
 import kafka.api.ApiVersion
 import kafka.log._
 import kafka.server._
 import kafka.server.checkpoints.OffsetCheckpoints
 import kafka.server.epoch.LeaderEpochFileCache
+import kafka.server.metadata.MockConfigRepository
 import kafka.utils._
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.{TopicPartition, Uuid}
@@ -68,7 +70,7 @@ class PartitionLockTest extends Logging {
   @BeforeEach
   def setUp(): Unit = {
     val logConfig = new LogConfig(new Properties)
-    val configRepository = TestUtils.createConfigRepository(topicPartition.topic, createLogProperties(Map.empty))
+    val configRepository = MockConfigRepository.forTopic(topicPartition.topic, createLogProperties(Map.empty))
     logManager = TestUtils.createLogManager(Seq(logDir), logConfig, configRepository,
       CleanerConfig(enableCleaner = false), mockTime)
     partition = setupPartitionWithMocks(logManager)

--- a/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionTest.scala
@@ -155,7 +155,6 @@ class PartitionTest extends AbstractPartitionTest {
   @Test
   def testMakeLeaderDoesNotUpdateEpochCacheForOldFormats(): Unit = {
     val leaderEpoch = 8
-
     configRepository.setTopicConfig(topicPartition.topic,
       LogConfig.MessageFormatVersionProp, kafka.api.KAFKA_0_10_2_IV0.shortVersion)
     val log = logManager.getOrCreateLog(topicPartition, topicId = None)

--- a/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/LogLoaderTest.scala
@@ -25,7 +25,7 @@ import java.util.Properties
 import kafka.api.{ApiVersion, KAFKA_0_11_0_IV0}
 import kafka.server.epoch.{EpochEntry, LeaderEpochFileCache}
 import kafka.server.{BrokerTopicStats, FetchDataInfo, KafkaConfig, LogDirFailureChannel}
-import kafka.server.metadata.CachedConfigRepository
+import kafka.server.metadata.MockConfigRepository
 import kafka.utils.{CoreUtils, MockTime, Scheduler, TestUtils}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.{CompressionType, ControlRecordType, DefaultRecordBatch, MemoryRecords, RecordBatch, RecordVersion, SimpleRecord, TimestampType}
@@ -75,7 +75,7 @@ class LogLoaderTest {
     // Create a LogManager with some overridden methods to facilitate interception of clean shutdown
     // flag and to inject a runtime error
     def interceptedLogManager(logConfig: LogConfig, logDirs: Seq[File], simulateError: SimulateError): LogManager = {
-      new LogManager(logDirs = logDirs.map(_.getAbsoluteFile), initialOfflineDirs = Array.empty[File], new CachedConfigRepository(),
+      new LogManager(logDirs = logDirs.map(_.getAbsoluteFile), initialOfflineDirs = Array.empty[File], new MockConfigRepository(),
         initialDefaultConfig = logConfig, cleanerConfig = CleanerConfig(enableCleaner = false), recoveryThreadsPerDataDir = 4,
         flushCheckMs = 1000L, flushRecoveryOffsetCheckpointMs = 10000L, flushStartOffsetCheckpointMs = 10000L,
         retentionCheckMs = 1000L, maxPidExpirationMs = 60 * 60 * 1000, scheduler = time.scheduler, time = time,

--- a/core/src/test/scala/unit/kafka/server/DescribeQuorumRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DescribeQuorumRequestTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kafka.server
+
+import java.io.IOException
+
+import kafka.test.ClusterInstance
+import kafka.test.annotation.{ClusterTest, ClusterTestDefaults, Type}
+import kafka.test.junit.ClusterTestExtensions
+import kafka.utils.NotNothing
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.DescribeQuorumRequest.singletonRequest
+import org.apache.kafka.common.requests.{AbstractRequest, AbstractResponse, ApiVersionsRequest, ApiVersionsResponse, DescribeQuorumRequest, DescribeQuorumResponse}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.extension.ExtendWith
+
+import scala.jdk.CollectionConverters._
+import scala.reflect.ClassTag
+
+@ExtendWith(value = Array(classOf[ClusterTestExtensions]))
+@ClusterTestDefaults(clusterType = Type.KRAFT)
+class DescribeQuorumRequestTest(cluster: ClusterInstance) {
+
+  @ClusterTest(clusterType = Type.ZK)
+  def testDescribeQuorumNotSupportedByZkBrokers(): Unit = {
+    val apiRequest = new ApiVersionsRequest.Builder().build()
+    val apiResponse =  connectAndReceive[ApiVersionsResponse](apiRequest)
+    assertNull(apiResponse.apiVersion(ApiKeys.DESCRIBE_QUORUM.id))
+
+    val describeQuorumRequest = new DescribeQuorumRequest.Builder(
+      singletonRequest(KafkaRaftServer.MetadataPartition)
+    ).build()
+
+    assertThrows(classOf[IOException], () => {
+      connectAndReceive[DescribeQuorumResponse](describeQuorumRequest)
+    })
+  }
+
+  @ClusterTest
+  def testDescribeQuorum(): Unit = {
+    val request = new DescribeQuorumRequest.Builder(
+      singletonRequest(KafkaRaftServer.MetadataPartition)
+    ).build()
+
+    val response = connectAndReceive[DescribeQuorumResponse](request)
+
+    assertEquals(Errors.NONE, Errors.forCode(response.data.errorCode))
+    assertEquals(1, response.data.topics.size)
+
+    val topicData = response.data.topics.get(0)
+    assertEquals(KafkaRaftServer.MetadataTopic, topicData.topicName)
+    assertEquals(1, topicData.partitions.size)
+
+    val partitionData = topicData.partitions.get(0)
+    assertEquals(KafkaRaftServer.MetadataPartition.partition, partitionData.partitionIndex)
+    assertEquals(Errors.NONE, Errors.forCode(partitionData.errorCode))
+    assertTrue(partitionData.leaderEpoch > 0)
+
+    val leaderId = partitionData.leaderId
+    assertTrue(leaderId > 0)
+
+    val leaderState = partitionData.currentVoters.asScala.find(_.replicaId == leaderId)
+      .getOrElse(throw new AssertionError("Failed to find leader among current voter states"))
+    assertTrue(leaderState.logEndOffset > 0)
+  }
+
+  private def connectAndReceive[T <: AbstractResponse](
+    request: AbstractRequest
+  )(
+    implicit classTag: ClassTag[T], nn: NotNothing[T]
+  ): T = {
+    IntegrationTestUtils.connectAndReceive(
+      request,
+      cluster.brokerSocketServers().asScala.head,
+      cluster.clientListener()
+    )
+  }
+
+}

--- a/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
+++ b/core/src/test/scala/unit/kafka/server/HighwatermarkPersistenceTest.scala
@@ -27,7 +27,7 @@ import kafka.utils.{KafkaScheduler, MockTime, TestUtils}
 import java.util.concurrent.atomic.AtomicBoolean
 
 import kafka.cluster.Partition
-import kafka.server.metadata.CachedConfigRepository
+import kafka.server.metadata.MockConfigRepository
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.record.SimpleRecord
 
@@ -35,7 +35,7 @@ class HighwatermarkPersistenceTest {
 
   val configs = TestUtils.createBrokerConfigs(2, TestUtils.MockZkConnect).map(KafkaConfig.fromProps)
   val topic = "foo"
-  val configRepository = new CachedConfigRepository()
+  val configRepository = new MockConfigRepository()
   val logManagers = configs map { config =>
     TestUtils.createLogManager(
       logDirs = config.logDirs.map(new File(_)),

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kafka.cluster.Partition
 import kafka.log.{Log, LogManager}
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.server.metadata.CachedConfigRepository
+import kafka.server.metadata.MockConfigRepository
 import kafka.utils.TestUtils.MockAlterIsrManager
 import kafka.utils._
 import org.apache.kafka.common.TopicPartition
@@ -68,7 +68,7 @@ class IsrExpirationTest {
     quotaManager = QuotaFactory.instantiate(configs.head, metrics, time, "")
     replicaManager = new ReplicaManager(configs.head, metrics, time, None, null, logManager, new AtomicBoolean(false),
       quotaManager, new BrokerTopicStats, MetadataCache.zkMetadataCache(configs.head.brokerId),
-      new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager, new CachedConfigRepository())
+      new LogDirFailureChannel(configs.head.logDirs.size), alterIsrManager, new MockConfigRepository())
   }
 
   @AfterEach

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -2080,7 +2080,7 @@ class KafkaApisTest {
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.EARLIEST_TIMESTAMP)
         .setCurrentLeaderEpoch(currentLeaderEpoch.get)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel)
+    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false)
       .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     val capturedResponse = expectNoThrottling(request)
@@ -3192,7 +3192,7 @@ class KafkaApisTest {
       .setPartitions(List(new ListOffsetsPartition()
         .setPartitionIndex(tp.partition)
         .setTimestamp(ListOffsetsRequest.LATEST_TIMESTAMP)).asJava)).asJava
-    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel)
+    val listOffsetRequest = ListOffsetsRequest.Builder.forConsumer(true, isolationLevel, false)
       .setTargetTimes(targetTimes).build()
     val request = buildRequest(listOffsetRequest)
     val capturedResponse = expectNoThrottling(request)

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -23,6 +23,7 @@ import java.util
 import java.util.Arrays.asList
 import java.util.concurrent.TimeUnit
 import java.util.{Collections, Optional, Properties, Random}
+
 import kafka.api.{ApiVersion, KAFKA_0_10_2_IV0, KAFKA_2_2_IV1, LeaderAndIsr}
 import kafka.cluster.{Broker, Partition}
 import kafka.controller.{ControllerContext, KafkaController}
@@ -32,7 +33,7 @@ import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinat
 import kafka.log.AppendOrigin
 import kafka.network.RequestChannel
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.server.metadata.{CachedConfigRepository, ClientQuotaCache, ConfigRepository, RaftMetadataCache}
+import kafka.server.metadata.{ClientQuotaCache, ConfigRepository, MockConfigRepository, RaftMetadataCache}
 import kafka.utils.{MockTime, TestUtils}
 import kafka.zk.KafkaZkClient
 import org.apache.kafka.clients.admin.AlterConfigOp.OpType
@@ -124,7 +125,7 @@ class KafkaApisTest {
   def createKafkaApis(interBrokerProtocolVersion: ApiVersion = ApiVersion.latestVersion,
                       authorizer: Option[Authorizer] = None,
                       enableForwarding: Boolean = false,
-                      configRepository: ConfigRepository = new CachedConfigRepository(),
+                      configRepository: ConfigRepository = new MockConfigRepository(),
                       raftSupport: Boolean = false,
                       overrideProperties: Map[String, String] = Map.empty): KafkaApis = {
 

--- a/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
+++ b/core/src/test/scala/unit/kafka/server/LogOffsetTest.scala
@@ -54,7 +54,7 @@ class LogOffsetTest extends BaseRequestTest {
   @Test
   def testGetOffsetsForUnknownTopic(): Unit = {
     val topicPartition = new TopicPartition("foo", 0)
-    val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
+    val request = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false)
       .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 10).asJava).build(0)
     val response = sendListOffsetsRequest(request)
     assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION.code, findPartition(response.topics.asScala, topicPartition).errorCode)
@@ -65,13 +65,7 @@ class LogOffsetTest extends BaseRequestTest {
   def testGetOffsetsAfterDeleteRecords(): Unit = {
     val topic = "kafka-"
     val topicPartition = new TopicPartition(topic, 0)
-
-    createTopic(topic, 1, 1)
-
-    val logManager = server.getLogManager
-    TestUtils.waitUntilTrue(() => logManager.getLog(topicPartition).isDefined,
-                  "Log for partition [topic,0] should be created")
-    val log = logManager.getLog(topicPartition).get
+    val log = createTopicAndGetLog(topic, topicPartition)
 
     for (_ <- 0 until 20)
       log.appendAsLeader(TestUtils.singletonRecords(value = Integer.toString(42).getBytes()), leaderEpoch = 0)
@@ -93,16 +87,51 @@ class LogOffsetTest extends BaseRequestTest {
   }
 
   @Test
+  def testFetchOffsetByTimestampForMaxTimestampAfterTruncate(): Unit = {
+    val topic = "kafka-"
+    val topicPartition = new TopicPartition(topic, 0)
+    val log = createTopicAndGetLog(topic, topicPartition)
+
+    for (timestamp <- 0 until 20)
+      log.appendAsLeader(TestUtils.singletonRecords(value = Integer.toString(42).getBytes(), timestamp = timestamp.toLong), leaderEpoch = 0)
+    log.flush()
+
+    log.updateHighWatermark(log.logEndOffset)
+
+    val firstOffset = log.fetchOffsetByTimestamp(ListOffsetsRequest.MAX_TIMESTAMP)
+    assertEquals(19L, firstOffset.get.offset)
+    assertEquals(19L, firstOffset.get.timestamp)
+
+    log.truncateTo(0)
+
+    val secondOffset = log.fetchOffsetByTimestamp(ListOffsetsRequest.MAX_TIMESTAMP)
+    assertEquals(0L, secondOffset.get.offset)
+    assertEquals(-1L, secondOffset.get.timestamp)
+  }
+
+  @Test
+  def testFetchOffsetByTimestampForMaxTimestampWithUnorderedTimestamps(): Unit = {
+    val topic = "kafka-"
+    val topicPartition = new TopicPartition(topic, 0)
+    val log = createTopicAndGetLog(topic, topicPartition)
+
+    for (timestamp <- List(0L, 1L, 2L, 3L, 4L, 6L, 5L))
+      log.appendAsLeader(TestUtils.singletonRecords(value = Integer.toString(42).getBytes(), timestamp = timestamp), leaderEpoch = 0)
+    log.flush()
+
+    log.updateHighWatermark(log.logEndOffset)
+
+    val maxTimestampOffset = log.fetchOffsetByTimestamp(ListOffsetsRequest.MAX_TIMESTAMP)
+    assertEquals(7L, log.logEndOffset)
+    assertEquals(5L, maxTimestampOffset.get.offset)
+    assertEquals(6L, maxTimestampOffset.get.timestamp)
+  }
+
+  @Test
   def testGetOffsetsBeforeLatestTime(): Unit = {
     val topic = "kafka-"
     val topicPartition = new TopicPartition(topic, 0)
-
-    createTopic(topic, 1, 1)
-
-    val logManager = server.getLogManager
-    TestUtils.waitUntilTrue(() => logManager.getLog(topicPartition).isDefined,
-      s"Log for partition $topicPartition should be created")
-    val log = logManager.getLog(topicPartition).get
+    val log = createTopicAndGetLog(topic, topicPartition)
 
     for (_ <- 0 until 20)
       log.appendAsLeader(TestUtils.singletonRecords(value = Integer.toString(42).getBytes()), leaderEpoch = 0)
@@ -111,7 +140,7 @@ class LogOffsetTest extends BaseRequestTest {
     val offsets = log.legacyFetchOffsetsBefore(ListOffsetsRequest.LATEST_TIMESTAMP, 15)
     assertEquals(Seq(20L, 18L, 16L, 14L, 12L, 10L, 8L, 6L, 4L, 2L, 0L), offsets)
 
-    TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, topicPartition.partition, server),
+    TestUtils.waitUntilTrue(() => TestUtils.isLeaderLocalOnBroker(topic, 0, server),
       "Leader should be elected")
     val request = ListOffsetsRequest.Builder.forReplica(0, 0)
       .setTargetTimes(buildTargetTimes(topicPartition, ListOffsetsRequest.LATEST_TIMESTAMP, 15).asJava).build()
@@ -147,6 +176,20 @@ class LogOffsetTest extends BaseRequestTest {
         offsetChanged = true
     }
     assertFalse(offsetChanged)
+  }
+
+  @Test
+  def testFetchOffsetByTimestampForMaxTimestampWithEmptyLog(): Unit = {
+    val topic = "kafka-"
+    val topicPartition = new TopicPartition(topic, 0)
+    val log = createTopicAndGetLog(topic, topicPartition)
+
+    log.updateHighWatermark(log.logEndOffset)
+
+    val maxTimestampOffset = log.fetchOffsetByTimestamp(ListOffsetsRequest.MAX_TIMESTAMP)
+    assertEquals(0L, log.logEndOffset)
+    assertEquals(0L, maxTimestampOffset.get.offset)
+    assertEquals(-1L, maxTimestampOffset.get.timestamp)
   }
 
   @deprecated("legacyFetchOffsetsBefore", since = "")
@@ -264,6 +307,15 @@ class LogOffsetTest extends BaseRequestTest {
   private def findPartition(topics: Buffer[ListOffsetsTopicResponse], tp: TopicPartition): ListOffsetsPartitionResponse = {
     topics.find(_.name == tp.topic).get
       .partitions.asScala.find(_.partitionIndex == tp.partition).get
+  }
+
+  private def createTopicAndGetLog(topic: String, topicPartition: TopicPartition): Log = {
+    createTopic(topic, 1, 1)
+
+    val logManager = server.getLogManager
+    TestUtils.waitUntilTrue(() => logManager.getLog(topicPartition).isDefined,
+      "Log for partition [topic,0] should be created")
+    logManager.getLog(topicPartition).get
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/RaftReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RaftReplicaManagerTest.scala
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kafka.cluster.Partition
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server.checkpoints.LazyOffsetCheckpoints
-import kafka.server.metadata.{CachedConfigRepository, MetadataBroker, MetadataBrokers, MetadataImage, MetadataImageBuilder, MetadataPartition, RaftMetadataCache}
+import kafka.server.metadata.{MetadataBroker, MetadataBrokers, MetadataImage, MetadataImageBuilder, MetadataPartition, MockConfigRepository, RaftMetadataCache}
 import kafka.utils.{MockScheduler, MockTime, TestUtils}
 import org.apache.kafka.common.errors.InconsistentTopicIdException
 import org.apache.kafka.common.{TopicPartition, Uuid}
@@ -46,7 +46,7 @@ trait LeadershipChangeHandler {
 class RaftReplicaManagerTest {
   private var alterIsrManager: AlterIsrManager = _
   private var config: KafkaConfig = _
-  private val configRepository = new CachedConfigRepository()
+  private val configRepository = new MockConfigRepository()
   private val metrics = new Metrics
   private var quotaManager: QuotaManagers = _
   private val time = new MockTime

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerQuotasTest.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.easymock.EasyMock
 import EasyMock._
 import kafka.server.QuotaFactory.QuotaManagers
-import kafka.server.metadata.CachedConfigRepository
+import kafka.server.metadata.MockConfigRepository
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.{AfterEach, Test}
 
@@ -199,7 +199,7 @@ class ReplicaManagerQuotasTest {
 
   def setUpMocks(fetchInfo: Seq[(TopicPartition, PartitionData)], record: SimpleRecord = this.record,
                  bothReplicasInSync: Boolean = false): Unit = {
-    val configRepository = new CachedConfigRepository()
+    val configRepository = new MockConfigRepository()
     val scheduler: KafkaScheduler = createNiceMock(classOf[KafkaScheduler])
 
     //Create log which handles both a regular read and a 0 bytes read

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerTest.scala
@@ -23,7 +23,7 @@ import kafka.log._
 import kafka.server.QuotaFactory.{QuotaManagers, UnboundedQuota}
 import kafka.server.checkpoints.{LazyOffsetCheckpoints, OffsetCheckpointFile}
 import kafka.server.epoch.util.ReplicaFetcherMockBlockingSend
-import kafka.server.metadata.CachedConfigRepository
+import kafka.server.metadata.MockConfigRepository
 import kafka.utils.TestUtils.createBroker
 import kafka.utils.timer.MockTimer
 import kafka.utils.{MockScheduler, MockTime, TestUtils}
@@ -63,7 +63,7 @@ class ReplicaManagerTest {
   val time = new MockTime
   val scheduler = new MockScheduler(time)
   val metrics = new Metrics
-  val configRepository = new CachedConfigRepository()
+  val configRepository = new MockConfigRepository()
   var alterIsrManager: AlterIsrManager = _
   var config: KafkaConfig = _
   var quotaManager: QuotaManagers = _

--- a/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
+++ b/core/src/test/scala/unit/kafka/server/RequestQuotaTest.scala
@@ -240,7 +240,7 @@ class RequestQuotaTest extends BaseRequestTest {
               .setPartitionIndex(tp.partition)
               .setTimestamp(0L)
               .setCurrentLeaderEpoch(15)).asJava)
-          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
+          ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false)
             .setTargetTimes(List(topic).asJava)
 
         case ApiKeys.LEADER_AND_ISR =>

--- a/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/OffsetsForLeaderEpochTest.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kafka.log.{Log, LogManager}
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.server._
-import kafka.server.metadata.CachedConfigRepository
+import kafka.server.metadata.MockConfigRepository
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.{OffsetForLeaderPartition, OffsetForLeaderTopic}
@@ -42,7 +42,7 @@ class OffsetsForLeaderEpochTest {
   private val time = new MockTime
   private val metrics = new Metrics
   private val alterIsrManager = TestUtils.createAlterIsrManager()
-  private val configRepository = new CachedConfigRepository()
+  private val configRepository = new MockConfigRepository()
   private val tp = new TopicPartition("topic", 1)
   private var replicaManager: ReplicaManager = _
   private var quotaManager: QuotaManagers = _

--- a/core/src/test/scala/unit/kafka/server/metadata/MockConfigRepositoryTest.scala
+++ b/core/src/test/scala/unit/kafka/server/metadata/MockConfigRepositoryTest.scala
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka.server.metadata
+
+import java.util.Properties
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MockConfigRepositoryTest {
+  @Test
+  def testEmptyRepository(): Unit = {
+    val repository = new MockConfigRepository()
+    assertEquals(new Properties(), repository.brokerConfig(0))
+    assertEquals(new Properties(), repository.topicConfig("foo"))
+  }
+
+  @Test
+  def testSetTopicConfig(): Unit = {
+    val repository = new MockConfigRepository()
+    val topic0 = "topic0"
+    repository.setTopicConfig(topic0, "foo", null)
+
+    val topic1 = "topic1"
+    repository.setTopicConfig(topic1, "foo", "bar")
+    val topicProperties = new Properties()
+    topicProperties.put("foo", "bar")
+    assertEquals(topicProperties, repository.topicConfig(topic1))
+
+    val topicProperties2 = new Properties()
+    topicProperties2.put("foo", "bar")
+    topicProperties2.put("foo2", "baz")
+    repository.setTopicConfig(topic1, "foo2", "baz") // add another prop
+    assertEquals(topicProperties2, repository.topicConfig(topic1)) // should get both props
+
+    repository.setTopicConfig(topic1, "foo2", null)
+    assertEquals(topicProperties, repository.topicConfig(topic1))
+  }
+}

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -1207,16 +1207,17 @@ object TestUtils extends Logging {
     values
   }
 
-  def produceMessage(servers: Seq[KafkaServer], topic: String, message: String,
+  def produceMessage(servers: Seq[KafkaServer], topic: String, message: String, timestamp: java.lang.Long = null,
                      deliveryTimeoutMs: Int = 30 * 1000, requestTimeoutMs: Int = 20 * 1000): Unit = {
     val producer = createProducer(TestUtils.getBrokerListStrFromServers(servers),
       deliveryTimeoutMs = deliveryTimeoutMs, requestTimeoutMs = requestTimeoutMs)
     try {
-      producer.send(new ProducerRecord(topic, topic.getBytes, message.getBytes)).get
+      producer.send(new ProducerRecord(topic, null, timestamp, topic.getBytes, message.getBytes)).get
     } finally {
       producer.close()
     }
   }
+
 
   def verifyTopicDeletion(zkClient: KafkaZkClient, topic: String, numPartitions: Int, servers: Seq[KafkaServer]): Unit = {
     val topicPartitions = (0 until numPartitions).map(new TopicPartition(topic, _))

--- a/core/src/test/scala/unit/kafka/utils/TestUtils.scala
+++ b/core/src/test/scala/unit/kafka/utils/TestUtils.scala
@@ -36,7 +36,7 @@ import kafka.log._
 import kafka.metrics.KafkaYammerMetrics
 import kafka.server._
 import kafka.server.checkpoints.OffsetCheckpointFile
-import kafka.server.metadata.{CachedConfigRepository, ConfigRepository, MetadataBroker}
+import kafka.server.metadata.{ConfigRepository, MetadataBroker, MockConfigRepository}
 import kafka.utils.Implicits._
 import kafka.zk._
 import org.apache.kafka.clients.CommonClientConfigs
@@ -1094,7 +1094,7 @@ object TestUtils extends Logging {
    */
   def createLogManager(logDirs: Seq[File] = Seq.empty[File],
                        defaultConfig: LogConfig = LogConfig(),
-                       configRepository: ConfigRepository = new CachedConfigRepository,
+                       configRepository: ConfigRepository = new MockConfigRepository,
                        cleanerConfig: CleanerConfig = CleanerConfig(enableCleaner = false),
                        time: MockTime = new MockTime()): LogManager = {
     new LogManager(logDirs = logDirs.map(_.getAbsoluteFile),
@@ -1171,12 +1171,6 @@ object TestUtils extends Logging {
 
   def createIsrChangeListener(): MockIsrChangeListener = {
     new MockIsrChangeListener()
-  }
-
-  def createConfigRepository(topic: String, props: Properties): CachedConfigRepository = {
-    val configRepository = new CachedConfigRepository()
-    props.entrySet().forEach(e => configRepository.setTopicConfig(topic, e.getKey.toString, e.getValue.toString))
-    configRepository
   }
 
   def produceMessages(servers: Seq[KafkaServer],

--- a/docs/streams/upgrade-guide.html
+++ b/docs/streams/upgrade-guide.html
@@ -121,10 +121,23 @@
     <p>
         The public <code>topicGroupId</code> and <code>partition</code> fields on TaskId have been deprecated and replaced with getters. Please migrate to using the new <code>TaskId.subtopology()</code>
         (which replaces <code>topicGroupId</code>) and <code>TaskId.partition()</code> APIs instead. Also, the <code>TaskId#readFrom</code> and <code>TaskId#writeTo</code> methods have been deprecated
-        and will be removed, as they were never intended for public use. Finally, we have deprecated the <code>TaskMetadata.taskId()</code> method as well as the <code>TaskMetadata</code> constructor.
-        These have been replaced with APIs that better represent the task id as an actual <code>TaskId</code> object instead of a String. Please migrate to the new <code>TaskMetadata#getTaskId</code>
-        method. See <a href="https://cwiki.apache.org/confluence/x/vYTOCg">KIP-740</a> for more details.
+        and will be removed, as they were never intended for public use. We have also deprecated the <code>org.apache.kafka.streams.processsor.TaskMetadata</code> class and introduced a new interface
+        <code>org.apache.kafka.streams.TaskMetadata</code> to be used instead. This change was introduced to better reflect the fact that <code>TaskMetadata</code> was not meant to be instantiated outside
+        of Kafka codebase.
+        Please note that the new <code>TaskMetadata</code> offers APIs that better represent the task id as an actual <code>TaskId</code> object instead of a String. Please migrate to the new
+        <code>org.apache.kafka.streams.TaskMetadata</code> which offers these better methods, for example, by using the new <code>ThreadMetadata#activeTasks</code> and <code>ThreadMetadata#standbyTasks</code>.
+        <code>org.apache.kafka.streams.processor.ThreadMetadata</code> class is also now deprecated and the newly introduced interface <code>org.apache.kafka.streams.ThreadMetadata</code> is to be used instead. In this new <code>ThreadMetadata</code>
+        interface, any reference to the deprecated <code>TaskMetadata</code> is replaced by the new interface.
+        Finally, also <code>org.apache.kafka.streams.state.StreamsMetadata</code> has been deprecated. Please migrate to the new <code>org.apache.kafka.streams.StreamsMetadata</code>.
+        We have deprecated several methods under <code>org.apache.kafka.streams.KafkaStreams</code> that returned the aforementioned deprecated classes:
     </p>
+    <ul>
+        <li>Users of <code>KafkaStreams#allMetadata</code> are meant to migrate to the new <code>KafkaStreams#metadataForAllStreamsClients</code>.</li>
+        <li>Users of <code>KafkaStreams#allMetadataForStore(String)</code> are meant to migrate to the new <code>KafkaStreams#streamsMetadataForStore(String)</code>.</li>
+        <li>Users of <code>KafkaStreams#localThreadsMetadata</code> are meant to migrate to the new <code>KafkaStreams#metadataForLocalThreads</code>.</li>
+    </ul>
+    <p>See <a href="https://cwiki.apache.org/confluence/x/vYTOCg">KIP-740</a> and <a href="https://cwiki.apache.org/confluence/x/XIrOCg">KIP-744</a> for more details.</p>
+
     <p>
         We removed the following deprecated APIs:
     </p>

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/common/ListOffsetRequestBenchmark.java
@@ -69,7 +69,7 @@ public class ListOffsetRequestBenchmark {
             }
         }
 
-        this.offsetRequest = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED)
+        this.offsetRequest = ListOffsetsRequest.Builder.forConsumer(false, IsolationLevel.READ_UNCOMMITTED, false)
                 .build(ApiKeys.LIST_OFFSETS.latestVersion());
     }
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -40,7 +40,7 @@ import kafka.server.ReplicaFetcherThread;
 import kafka.server.ReplicaManager;
 import kafka.server.ReplicaQuota;
 import kafka.server.checkpoints.OffsetCheckpoints;
-import kafka.server.metadata.CachedConfigRepository;
+import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
 import kafka.utils.Pool;
 import org.apache.kafka.common.TopicPartition;
@@ -123,7 +123,7 @@ public class ReplicaFetcherThreadBenchmark {
         LogDirFailureChannel logDirFailureChannel = Mockito.mock(LogDirFailureChannel.class);
         logManager = new LogManager(JavaConverters.asScalaIteratorConverter(logDirs.iterator()).asScala().toSeq(),
                 JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
-                new CachedConfigRepository(),
+                new MockConfigRepository(),
                 logConfig,
                 new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
                 1,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/metadata/MetadataRequestBenchmark.java
@@ -39,7 +39,7 @@ import kafka.server.ReplicationQuotaManager;
 import kafka.server.SimpleApiVersionManager;
 import kafka.server.ZkAdminManager;
 import kafka.server.ZkSupport;
-import kafka.server.metadata.CachedConfigRepository;
+import kafka.server.metadata.MockConfigRepository;
 import kafka.zk.KafkaZkClient;
 import org.apache.kafka.common.memory.MemoryPool;
 import org.apache.kafka.common.message.ApiMessageType;
@@ -181,7 +181,7 @@ public class MetadataRequestBenchmark {
             autoTopicCreationManager,
             brokerId,
             config,
-            new CachedConfigRepository(),
+            new MockConfigRepository(),
             metadataCache,
             metrics,
             Option.empty(),

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -30,7 +30,7 @@ import kafka.server.BrokerTopicStats;
 import kafka.server.LogDirFailureChannel;
 import kafka.server.MetadataCache;
 import kafka.server.checkpoints.OffsetCheckpoints;
-import kafka.server.metadata.CachedConfigRepository;
+import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -102,7 +102,7 @@ public class PartitionMakeFollowerBenchmark {
         LogDirFailureChannel logDirFailureChannel = Mockito.mock(LogDirFailureChannel.class);
         logManager = new LogManager(JavaConverters.asScalaIteratorConverter(logDirs.iterator()).asScala().toSeq(),
             JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
-            new CachedConfigRepository(),
+            new MockConfigRepository(),
             logConfig,
             new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
             1,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -31,7 +31,7 @@ import kafka.server.LogDirFailureChannel;
 import kafka.server.LogOffsetMetadata;
 import kafka.server.MetadataCache;
 import kafka.server.checkpoints.OffsetCheckpoints;
-import kafka.server.metadata.CachedConfigRepository;
+import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
@@ -87,7 +87,7 @@ public class UpdateFollowerFetchStateBenchmark {
         List<File> logDirs = Collections.singletonList(logDir);
         logManager = new LogManager(JavaConverters.asScalaIteratorConverter(logDirs.iterator()).asScala().toSeq(),
                 JavaConverters.asScalaIteratorConverter(new ArrayList<File>().iterator()).asScala().toSeq(),
-                new CachedConfigRepository(),
+                new MockConfigRepository(),
                 logConfig,
                 new CleanerConfig(0, 0, 0, 0, 0, 0.0, 0, false, "MD5"),
                 1,

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/RecordHeaderBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/record/RecordHeaderBenchmark.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.jmh.record;
+
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.openjdk.jmh.annotations.*;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.*;
+
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 15)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class RecordHeaderBenchmark {
+
+    private final ByteBuffer keyBuffer = ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8));
+    private final ByteBuffer valueBuffer = ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8));
+
+    @Benchmark
+    public void key() {
+        new RecordHeader(keyBuffer, valueBuffer).key();
+    }
+
+    @Benchmark
+    public void value() {
+        new RecordHeader(keyBuffer, valueBuffer).value();
+    }
+
+}

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/server/CheckpointBench.java
@@ -28,7 +28,7 @@ import kafka.server.MetadataCache;
 import kafka.server.QuotaFactory;
 import kafka.server.ReplicaManager;
 import kafka.server.checkpoints.OffsetCheckpoints;
-import kafka.server.metadata.CachedConfigRepository;
+import kafka.server.metadata.MockConfigRepository;
 import kafka.utils.KafkaScheduler;
 import kafka.utils.MockTime;
 import kafka.utils.Scheduler;
@@ -88,7 +88,7 @@ public class CheckpointBench {
     private LogDirFailureChannel failureChannel;
     private LogManager logManager;
     private AlterIsrManager alterIsrManager;
-    private final CachedConfigRepository configRepository = new CachedConfigRepository();
+    private final MockConfigRepository configRepository = new MockConfigRepository();
 
 
     @SuppressWarnings("deprecation")
@@ -105,7 +105,7 @@ public class CheckpointBench {
         final List<File> files =
             JavaConverters.seqAsJavaList(brokerProperties.logDirs()).stream().map(File::new).collect(Collectors.toList());
         this.logManager = TestUtils.createLogManager(JavaConverters.asScalaBuffer(files),
-                LogConfig.apply(), new CachedConfigRepository(), CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
+                LogConfig.apply(), new MockConfigRepository(), CleanerConfig.apply(1, 4 * 1024 * 1024L, 0.9d,
                         1024 * 1024, 32 * 1024 * 1024,
                         Double.MAX_VALUE, 15 * 1000, true, "MD5"), time);
         scheduler.startup();

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsBuilder.java
@@ -236,7 +236,7 @@ public class StreamsBuilder {
      * K key = "some-key";
      * ValueAndTimestamp<V> valueForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * @param topic              the topic name; cannot be {@code null}

--- a/streams/src/main/java/org/apache/kafka/streams/StreamsMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/StreamsMetadata.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.state.HostInfo;
+
+import java.util.Set;
+
+/**
+ * Metadata of a Kafka Streams client.
+ */
+public interface StreamsMetadata {
+
+    /**
+     * The value of {@link StreamsConfig#APPLICATION_SERVER_CONFIG} configured for the Streams
+     * client.
+     *
+     * @return {@link HostInfo} corresponding to the Streams client
+     */
+    HostInfo hostInfo();
+
+    /**
+     * Names of the state stores assigned to active tasks of the Streams client.
+     *
+     * @return names of the state stores assigned to active tasks
+     */
+    Set<String> stateStoreNames();
+
+    /**
+     * Source topic partitions of the active tasks of the Streams client.
+     *
+     * @return source topic partitions of the active tasks
+     */
+    Set<TopicPartition> topicPartitions();
+
+    /**
+     * Changelog topic partitions for the state stores the standby tasks of the Streams client replicates.
+     *
+     * @return set of changelog topic partitions of the standby tasks
+     */
+    Set<TopicPartition> standbyTopicPartitions();
+
+    /**
+     * Names of the state stores assigned to standby tasks of the Streams client.
+     *
+     * @return names of the state stores assigned to standby tasks
+     */
+    Set<String> standbyStateStoreNames();
+
+    /**
+     * Host where the Streams client runs. 
+     *
+     * This method is equivalent to {@code StreamsMetadata.hostInfo().host();}
+     *
+     * @return the host where the Streams client runs
+     */
+    String host();
+
+    /**
+     * Port on which the Streams client listens.
+     * 
+     * This method is equivalent to {@code StreamsMetadata.hostInfo().port();}
+     *
+     * @return the port on which Streams client listens
+     */
+    int port();
+
+    /**
+     * Compares the specified object with this StreamsMetadata. Returns {@code true} if and only if the specified object is
+     * also a StreamsMetadata and for both {@code hostInfo()} are equal, and {@code stateStoreNames()}, {@code topicPartitions()},
+     * {@code standbyStateStoreNames()}, and {@code standbyTopicPartitions()} contain the same elements.
+     *
+     * @return {@code true} if this object is the same as the obj argument; {@code false} otherwise.
+     */
+    boolean equals(Object o);
+
+    /**
+     * Returns the hash code value for this TaskMetadata. The hash code of a list is defined to be the result of the following calculation:
+     * <pre>
+     * {@code
+     * Objects.hash(hostInfo(), stateStoreNames(), topicPartitions(), standbyStateStoreNames(), standbyTopicPartitions());
+     * }
+     * </pre>
+     *
+     * @return a hash code value for this object.
+     */
+    int hashCode();
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/TaskMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/TaskMetadata.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.processor.TaskId;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+
+/**
+ * Metadata of a task.
+ */
+public interface TaskMetadata {
+
+    /**
+     * Task ID of the task.
+     *
+     * @return task ID consisting of subtopology and partition ID
+     */
+    TaskId taskId();
+
+    /**
+     * Source topic partitions of the task.
+     *
+     * @return source topic partitions
+     */
+    Set<TopicPartition> topicPartitions();
+
+    /**
+     * Offsets of the source topic partitions committed so far by the task.
+     *
+     * @return map from source topic partitions to committed offsets
+     */
+    Map<TopicPartition, Long> committedOffsets();
+
+    /**
+     * End offsets of the source topic partitions of the task.
+     *
+     * @return map source topic partition to end offsets
+     */
+    Map<TopicPartition, Long> endOffsets();
+
+    /**
+     * Time task idling started. If the task is not currently idling it will return empty.
+     *
+     * @return time when task idling started, empty {@code Optional} if the task is currently not idling
+     */
+    Optional<Long> timeCurrentIdlingStarted();
+
+    /**
+     * Compares the specified object with this TaskMetadata. Returns {@code true} if and only if the specified object is
+     * also a TaskMetadata and both {@code taskId()} and {@code topicPartitions()} are equal.
+     *
+     * @return {@code true} if this object is the same as the obj argument; {@code false} otherwise.
+     */
+    boolean equals(final Object o);
+
+    /**
+     * Returns the hash code value for this TaskMetadata. The hash code of a list is defined to be the result of the following calculation:
+     * <pre>
+     * {@code
+     * Objects.hash(taskId(), topicPartitions());
+     * }
+     * </pre>
+     *
+     * @return a hash code value for this object.
+     */
+    int hashCode();
+
+}

--- a/streams/src/main/java/org/apache/kafka/streams/ThreadMetadata.java
+++ b/streams/src/main/java/org/apache/kafka/streams/ThreadMetadata.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams;
+
+import java.util.Set;
+
+/**
+ * Metadata of a stream thread.
+ */
+public interface ThreadMetadata {
+
+
+    /**
+     * State of the stream thread
+     *
+     * @return the state
+     */
+    String threadState();
+
+    /**
+     * Name of the stream thread
+     *
+     * @return the name
+     */
+    String threadName();
+
+    /**
+     * Metadata of the active tasks assigned to the stream thread.
+     *
+     * @return metadata of the active tasks
+     */
+    Set<TaskMetadata> activeTasks();
+
+    /**
+     * Metadata of the standby tasks assigned to the stream thread.
+     *
+     * @return metadata of the standby tasks
+
+     */
+    Set<TaskMetadata> standbyTasks();
+
+    /**
+     * Client ID of the Kafka consumer used by the stream thread.
+     *
+     * @return client ID of the Kafka consumer
+     */
+    String consumerClientId();
+
+    /**
+     * Client ID of the restore Kafka consumer used by the stream thread
+     *
+     * @return client ID of the restore Kafka consumer
+     */
+    String restoreConsumerClientId();
+
+    /**
+     * Client IDs of the Kafka producers used by the stream thread.
+     *
+     * @return client IDs of the Kafka producers
+     */
+    Set<String> producerClientIds();
+
+    /**
+     * Client ID of the admin client used by the stream thread.
+     *
+     * @return client ID of the admin client
+     */
+    String adminClientId();
+
+    /**
+     * Compares the specified object with this ThreadMetadata. Returns {@code true} if and only if the specified object is
+     * also a ThreadMetadata and both {@code threadName()} are equal, {@code threadState()} are equal, {@code activeTasks()} contain the same
+     * elements, {@code standbyTasks()} contain the same elements, {@code mainConsumerClientId()} are equal, {@code restoreConsumerClientId()}
+     * are equal, {@code producerClientIds()} are equal, {@code producerClientIds} contain the same elements, and {@code adminClientId()} are equal.
+     *
+     * @return {@code true} if this object is the same as the obj argument; {@code false} otherwise.
+     */
+    boolean equals(Object o);
+
+    /**
+     * Returns the hash code value for this ThreadMetadata. The hash code of a list is defined to be the result of the following calculation:
+     * <pre>
+     * {@code
+     * Objects.hash(
+     *             threadName,
+     *             threadState,
+     *             activeTasks,
+     *             standbyTasks,
+     *             mainConsumerClientId,
+     *             restoreConsumerClientId,
+     *             producerClientIds,
+     *             adminClientId);
+     * </pre>
+     *
+     * @return a hash code value for this object.
+     */
+    int hashCode();
+}

--- a/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStorePartitionException.java
+++ b/streams/src/main/java/org/apache/kafka/streams/errors/InvalidStateStorePartitionException.java
@@ -21,7 +21,7 @@ import org.apache.kafka.streams.KafkaStreams;
 /**
  * Indicates that the specific state store being queried via
  * {@link org.apache.kafka.streams.StoreQueryParameters} used a partitioning that is not assigned to this instance.
- * You can use {@link KafkaStreams#allMetadata()} to discover the correct instance that hosts the requested partition.
+ * You can use {@link KafkaStreams#metadataForAllStreamsClients()} to discover the correct instance that hosts the requested partition.
  */
 public class InvalidStateStorePartitionException extends InvalidStateStoreException {
 

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/CogroupedKStream.java
@@ -90,7 +90,7 @@ public interface CogroupedKStream<K, VOut> {
      * K key = "some-key";
      * ValueAndTimestamp<VOut> aggForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to query
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to query
      * the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedKeyValueStore}) will be backed by
@@ -140,7 +140,7 @@ public interface CogroupedKStream<K, VOut> {
      * K key = "some-key";
      * ValueAndTimestamp<VOut> aggForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to query
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to query
      * the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedKeyValueStore}) will be backed by
@@ -191,7 +191,7 @@ public interface CogroupedKStream<K, VOut> {
      * K key = "some-key";
      * ValueAndTimestamp<VOut> aggForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to query
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to query
      * the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedKeyValueStore} -- regardless of what
@@ -244,7 +244,7 @@ public interface CogroupedKStream<K, VOut> {
      * K key = "some-key";
      * ValueAndTimestamp<VOut> aggForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to query
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to query
      * the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedKeyValueStore} -- regardless of what

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedStream.java
@@ -124,7 +124,7 @@ public interface KGroupedStream<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<Long> countForWord = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * <p>
@@ -170,7 +170,7 @@ public interface KGroupedStream<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<Long> countForWord = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * <p>
@@ -274,7 +274,7 @@ public interface KGroupedStream<K, V> {
      * K key = "some-key";
      * ValueAndTimestamp<V> reduceForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * <p>
@@ -338,7 +338,7 @@ public interface KGroupedStream<K, V> {
      * K key = "some-key";
      * ValueAndTimestamp<V> reduceForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * <p>
@@ -443,7 +443,7 @@ public interface KGroupedStream<K, V> {
      * K key = "some-key";
      * ValueAndTimestamp<VR> aggForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * <p>
@@ -502,7 +502,7 @@ public interface KGroupedStream<K, V> {
      * K key = "some-key";
      * ValueAndTimestamp<VR> aggForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * <p>

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KGroupedTable.java
@@ -63,7 +63,7 @@ public interface KGroupedTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<Long> countForWord = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * <p>
@@ -106,7 +106,7 @@ public interface KGroupedTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<Long> countForWord = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      *
      * <p>
@@ -234,7 +234,7 @@ public interface KGroupedTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<V> reduceForWord = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -307,7 +307,7 @@ public interface KGroupedTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<V> reduceForWord = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -445,7 +445,7 @@ public interface KGroupedTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<VR> aggregateForWord = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -529,7 +529,7 @@ public interface KGroupedTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<VR> aggregateForWord = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/KTable.java
@@ -138,7 +138,7 @@ public interface KTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<V> valueForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * The store name to query with is specified by {@link Materialized#as(String)} or {@link Materialized#as(KeyValueBytesStoreSupplier)}.
      * <p>
@@ -177,7 +177,7 @@ public interface KTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<V> valueForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * The store name to query with is specified by {@link Materialized#as(String)} or {@link Materialized#as(KeyValueBytesStoreSupplier)}.
      * <p>
@@ -263,7 +263,7 @@ public interface KTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<V> valueForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * The store name to query with is specified by {@link Materialized#as(String)} or {@link Materialized#as(KeyValueBytesStoreSupplier)}.
      * <p>
@@ -301,7 +301,7 @@ public interface KTable<K, V> {
      * K key = "some-word";
      * ValueAndTimestamp<V> valueForKey = localStore.get(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * The store name to query with is specified by {@link Materialized#as(String)} or {@link Materialized#as(KeyValueBytesStoreSupplier)}.
      * <p>
@@ -466,7 +466,7 @@ public interface KTable<K, V> {
      * <p>
      * To query the local {@link KeyValueStore} representing outputTable above it must be obtained via
      * {@link KafkaStreams#store(StoreQueryParameters) KafkaStreams#store(...)}:
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * The store name to query with is specified by {@link Materialized#as(String)} or {@link Materialized#as(KeyValueBytesStoreSupplier)}.
      * <p>
@@ -512,7 +512,7 @@ public interface KTable<K, V> {
      * <p>
      * To query the local {@link KeyValueStore} representing outputTable above it must be obtained via
      * {@link KafkaStreams#store(StoreQueryParameters) KafkaStreams#store(...)}:
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * The store name to query with is specified by {@link Materialized#as(String)} or {@link Materialized#as(KeyValueBytesStoreSupplier)}.
      * <p>
@@ -560,7 +560,7 @@ public interface KTable<K, V> {
      * <p>
      * To query the local {@link KeyValueStore} representing outputTable above it must be obtained via
      * {@link KafkaStreams#store(StoreQueryParameters)}  KafkaStreams#store(...)}:
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * The store name to query with is specified by {@link Materialized#as(String)} or {@link Materialized#as(KeyValueBytesStoreSupplier)}.
      * <p>
@@ -607,7 +607,7 @@ public interface KTable<K, V> {
      * <p>
      * To query the local {@link KeyValueStore} representing outputTable above it must be obtained via
      * {@link KafkaStreams#store(StoreQueryParameters) KafkaStreams#store(...)}:
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * The store name to query with is specified by {@link Materialized#as(String)} or {@link Materialized#as(KeyValueBytesStoreSupplier)}.
      * <p>

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedCogroupedKStream.java
@@ -181,7 +181,7 @@ public interface SessionWindowedCogroupedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<Long> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -238,7 +238,7 @@ public interface SessionWindowedCogroupedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> aggForKeyForSession = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/SessionWindowedKStream.java
@@ -138,7 +138,7 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> sumForKeyForWindows = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -184,7 +184,7 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> sumForKeyForWindows = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -342,7 +342,7 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> aggForKeyForSession = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -403,7 +403,7 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> aggForKeyForSession = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -561,7 +561,7 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> sumForKeyForWindows = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.
@@ -621,7 +621,7 @@ public interface SessionWindowedKStream<K, V> {
      * String key = "some-key";
      * KeyValueIterator<Windowed<String>, Long> sumForKeyForWindows = localWindowStore.fetch(key); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store will be backed by an internal changelog topic that will be created in Kafka.

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedCogroupedKStream.java
@@ -171,7 +171,7 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<ValueAndTimestamp<V>> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedWindowStore} -- regardless of what
@@ -228,7 +228,7 @@ public interface TimeWindowedCogroupedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<ValueAndTimestamp<V>> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedWindowStore} -- regardless of what

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/TimeWindowedKStream.java
@@ -141,7 +141,7 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<ValueAndTimestamp<Long>> countForWordsForWindows = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedWindowStore} -- regardless of what
@@ -190,7 +190,7 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<ValueAndTimestamp<Long>> countForWordsForWindows = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedWindowStore} -- regardless of what
@@ -341,7 +341,7 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<ValueAndTimestamp<VR>> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedWindowStore} -- regardless of what
@@ -402,7 +402,7 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<ValueAndTimestamp<VR>> aggregateStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedWindowStore} -- regardless of what
@@ -562,7 +562,7 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<ValueAndTimestamp<V>> reduceStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedWindowStore} -- regardless of what
@@ -625,7 +625,7 @@ public interface TimeWindowedKStream<K, V> {
      * long toTime = ...;
      * WindowStoreIterator<ValueAndTimestamp<V>> reduceStore = localWindowStore.fetch(key, timeFrom, timeTo); // key must be local (application state is shared over all running Kafka Streams instances)
      * }</pre>
-     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#allMetadata()} to
+     * For non-local keys, a custom RPC mechanism must be implemented using {@link KafkaStreams#metadataForAllStreamsClients()} to
      * query the value of the key on a parallel running instance of your Kafka Streams application.
      * <p>
      * For failure and recovery the store (which always will be of type {@link TimestampedWindowStore} -- regardless of what

--- a/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
+++ b/streams/src/main/java/org/apache/kafka/streams/kstream/internals/InternalStreamsBuilder.java
@@ -102,7 +102,7 @@ public class InternalStreamsBuilder implements InternalNameProvider {
 
     public <K, V> KStream<K, V> stream(final Pattern topicPattern,
                                        final ConsumedInternal<K, V> consumed) {
-        final String name = newProcessorName(KStreamImpl.SOURCE_NAME);
+        final String name = new NamedInternal(consumed.name()).orElseGenerateWithPrefix(this, KStreamImpl.SOURCE_NAME);
         final StreamSourceNode<K, V> streamPatternSourceNode = new StreamSourceNode<>(name, topicPattern, consumed);
 
         addGraphNode(root, streamPatternSourceNode);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamThread.java
@@ -34,14 +34,14 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TaskMetadata;
+import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.internals.metrics.ClientMetrics;
 import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.TaskMetadata;
-import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.processor.internals.assignment.AssignorError;
 import org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -1118,7 +1118,7 @@ public class StreamThread extends Thread {
     // package-private for testing only
     StreamThread updateThreadMetadata(final String adminClientId) {
 
-        threadMetadata = new ThreadMetadata(
+        threadMetadata = new ThreadMetadataImpl(
             getName(),
             state().name(),
             getConsumerClientId(getName()),
@@ -1135,7 +1135,7 @@ public class StreamThread extends Thread {
                                       final Map<TaskId, Task> standbyTasks) {
         final Set<TaskMetadata> activeTasksMetadata = new HashSet<>();
         for (final Map.Entry<TaskId, Task> task : activeTasks.entrySet()) {
-            activeTasksMetadata.add(new TaskMetadata(
+            activeTasksMetadata.add(new TaskMetadataImpl(
                 task.getValue().id(),
                 task.getValue().inputPartitions(),
                 task.getValue().committedOffsets(),
@@ -1145,7 +1145,7 @@ public class StreamThread extends Thread {
         }
         final Set<TaskMetadata> standbyTasksMetadata = new HashSet<>();
         for (final Map.Entry<TaskId, Task> task : standbyTasks.entrySet()) {
-            standbyTasksMetadata.add(new TaskMetadata(
+            standbyTasksMetadata.add(new TaskMetadataImpl(
                 task.getValue().id(),
                 task.getValue().inputPartitions(),
                 task.getValue().committedOffsets(),
@@ -1155,7 +1155,7 @@ public class StreamThread extends Thread {
         }
 
         final String adminClientId = threadMetadata.adminClientId();
-        threadMetadata = new ThreadMetadata(
+        threadMetadata = new ThreadMetadataImpl(
             getName(),
             state().name(),
             getConsumerClientId(getName()),

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/StreamsMetadataState.java
@@ -27,7 +27,8 @@ import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.StreamsMetadata;
+import org.apache.kafka.streams.StreamsMetadata;
+import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,7 +93,7 @@ public class StreamsMetadataState {
     public Collection<StreamsMetadata> getAllMetadata() {
         return Collections.unmodifiableList(allMetadata);
     }
-    
+
     /**
      * Find all of the {@link StreamsMetadata}s for a given storeName
      *
@@ -229,11 +230,12 @@ public class StreamsMetadataState {
                                  final Map<HostInfo, Set<TopicPartition>> standbyPartitionHostMap) {
         if (activePartitionHostMap.isEmpty() && standbyPartitionHostMap.isEmpty()) {
             allMetadata = Collections.emptyList();
-            localMetadata.set(new StreamsMetadata(thisHost,
-                                                  Collections.emptySet(),
-                                                  Collections.emptySet(),
-                                                  Collections.emptySet(),
-                                                  Collections.emptySet()
+            localMetadata.set(new StreamsMetadataImpl(
+                thisHost,
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet(),
+                Collections.emptySet()
             ));
             return;
         }
@@ -258,11 +260,12 @@ public class StreamsMetadataState {
                     standbyStoresOnHost.addAll(getStoresOnHost(storeToSourceTopics, standbyPartitionsOnHost));
                 }
 
-                final StreamsMetadata metadata = new StreamsMetadata(hostInfo,
-                                                                     activeStoresOnHost,
-                                                                     activePartitionsOnHost,
-                                                                     standbyStoresOnHost,
-                                                                     standbyPartitionsOnHost);
+                final StreamsMetadata metadata = new StreamsMetadataImpl(
+                    hostInfo,
+                    activeStoresOnHost,
+                    activePartitionsOnHost,
+                    standbyStoresOnHost,
+                    standbyPartitionsOnHost);
                 rebuiltMetadata.add(metadata);
                 if (hostInfo.equals(thisHost)) {
                     localMetadata.set(metadata);

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskMetadataImpl.java
@@ -14,10 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.processor;
+package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.TaskMetadata;
+import org.apache.kafka.streams.processor.TaskId;
 
 import java.util.Collections;
 import java.util.Map;
@@ -25,14 +26,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-/**
- * Represents the state of a single task running within a {@link KafkaStreams} application.
- * @deprecated since 3.0, use {@link org.apache.kafka.streams.TaskMetadata} instead.
- */
-@Deprecated
-public class TaskMetadata {
+public class TaskMetadataImpl implements TaskMetadata {
 
-    private final String taskId;
+    private final TaskId taskId;
 
     private final Set<TopicPartition> topicPartitions;
 
@@ -42,11 +38,11 @@ public class TaskMetadata {
 
     private final Optional<Long> timeCurrentIdlingStarted;
 
-    public TaskMetadata(final String taskId,
-                        final Set<TopicPartition> topicPartitions,
-                        final Map<TopicPartition, Long> committedOffsets,
-                        final Map<TopicPartition, Long> endOffsets,
-                        final Optional<Long> timeCurrentIdlingStarted) {
+    public TaskMetadataImpl(final TaskId taskId,
+                            final Set<TopicPartition> topicPartitions,
+                            final Map<TopicPartition, Long> committedOffsets,
+                            final Map<TopicPartition, Long> endOffsets,
+                            final Optional<Long> timeCurrentIdlingStarted) {
         this.taskId = taskId;
         this.topicPartitions = Collections.unmodifiableSet(topicPartitions);
         this.committedOffsets = Collections.unmodifiableMap(committedOffsets);
@@ -54,34 +50,27 @@ public class TaskMetadata {
         this.timeCurrentIdlingStarted = timeCurrentIdlingStarted;
     }
 
-    /**
-     * @return the basic task metadata such as subtopology and partition id
-     */
-    public String taskId() {
+    @Override
+    public TaskId taskId() {
         return taskId;
     }
 
+    @Override
     public Set<TopicPartition> topicPartitions() {
         return topicPartitions;
     }
 
-    /**
-     * This function will return a map of TopicPartitions and the highest committed offset seen so far
-     */
+    @Override
     public Map<TopicPartition, Long> committedOffsets() {
         return committedOffsets;
     }
 
-    /**
-     * This function will return a map of TopicPartitions and the highest offset seen so far in the Topic
-     */
+    @Override
     public Map<TopicPartition, Long> endOffsets() {
         return endOffsets;
     }
 
-    /**
-     * This function will return the time task idling started, if the task is not currently idling it will return empty
-     */
+    @Override
     public Optional<Long> timeCurrentIdlingStarted() {
         return timeCurrentIdlingStarted;
     }
@@ -94,9 +83,9 @@ public class TaskMetadata {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final TaskMetadata that = (TaskMetadata) o;
+        final TaskMetadataImpl that = (TaskMetadataImpl) o;
         return Objects.equals(taskId, that.taskId) &&
-               Objects.equals(topicPartitions, that.topicPartitions);
+                Objects.equals(topicPartitions, that.topicPartitions);
     }
 
     @Override

--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImpl.java
@@ -14,9 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.processor;
+package org.apache.kafka.streams.processor.internals;
 
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.TaskMetadata;
+import org.apache.kafka.streams.ThreadMetadata;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -24,10 +26,8 @@ import java.util.Set;
 
 /**
  * Represents the state of a single thread running within a {@link KafkaStreams} application.
- * @deprecated since 3.0 use {@link org.apache.kafka.streams.ThreadMetadata} instead
  */
-@Deprecated
-public class ThreadMetadata {
+public class ThreadMetadataImpl implements ThreadMetadata {
 
     private final String threadName;
 
@@ -47,23 +47,24 @@ public class ThreadMetadata {
     // we keep it at the thread-level for user's convenience and possible extensions in the future
     private final String adminClientId;
 
-    public ThreadMetadata(final String threadName,
-                          final String threadState,
-                          final String mainConsumerClientId,
-                          final String restoreConsumerClientId,
-                          final Set<String> producerClientIds,
-                          final String adminClientId,
-                          final Set<org.apache.kafka.streams.processor.TaskMetadata> activeTasks,
-                          final Set<org.apache.kafka.streams.processor.TaskMetadata> standbyTasks) {
+    public ThreadMetadataImpl(final String threadName,
+                              final String threadState,
+                              final String mainConsumerClientId,
+                              final String restoreConsumerClientId,
+                              final Set<String> producerClientIds,
+                              final String adminClientId,
+                              final Set<TaskMetadata> activeTasks,
+                              final Set<TaskMetadata> standbyTasks) {
         this.mainConsumerClientId = mainConsumerClientId;
         this.restoreConsumerClientId = restoreConsumerClientId;
-        this.producerClientIds = producerClientIds;
+        this.producerClientIds = Collections.unmodifiableSet(producerClientIds);
         this.adminClientId = adminClientId;
         this.threadName = threadName;
         this.threadState = threadState;
         this.activeTasks = Collections.unmodifiableSet(activeTasks);
         this.standbyTasks = Collections.unmodifiableSet(standbyTasks);
     }
+
 
     public String threadState() {
         return threadState;
@@ -73,11 +74,12 @@ public class ThreadMetadata {
         return threadName;
     }
 
-    public Set<org.apache.kafka.streams.processor.TaskMetadata> activeTasks() {
+
+    public Set<TaskMetadata> activeTasks() {
         return activeTasks;
     }
 
-    public Set<org.apache.kafka.streams.processor.TaskMetadata> standbyTasks() {
+    public Set<TaskMetadata> standbyTasks() {
         return standbyTasks;
     }
 
@@ -105,7 +107,7 @@ public class ThreadMetadata {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final ThreadMetadata that = (ThreadMetadata) o;
+        final ThreadMetadataImpl that = (ThreadMetadataImpl) o;
         return Objects.equals(threadName, that.threadName) &&
                Objects.equals(threadState, that.threadState) &&
                Objects.equals(activeTasks, that.activeTasks) &&

--- a/streams/src/main/java/org/apache/kafka/streams/state/HostInfo.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/HostInfo.java
@@ -27,8 +27,8 @@ import org.apache.kafka.streams.processor.internals.StreamsPartitionAssignor;
 /**
  * Represents a user defined endpoint in a {@link org.apache.kafka.streams.KafkaStreams} application.
  * Instances of this class can be obtained by calling one of:
- *  {@link KafkaStreams#allMetadata()}
- *  {@link KafkaStreams#allMetadataForStore(String)}
+ *  {@link KafkaStreams#metadataForAllStreamsClients()}
+ *  {@link KafkaStreams#streamsMetadataForStore(String)}
  *
  *  The HostInfo is constructed during Partition Assignment
  *  see {@link StreamsPartitionAssignor}

--- a/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamsMetadataImpl.java
+++ b/streams/src/main/java/org/apache/kafka/streams/state/internals/StreamsMetadataImpl.java
@@ -14,13 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.streams.state;
+package org.apache.kafka.streams.state.internals;
 
-import java.util.Objects;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsMetadata;
+import org.apache.kafka.streams.state.HostInfo;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -29,19 +31,18 @@ import java.util.Set;
  * APIs and services to connect to other instances, the Set of state stores available on
  * the instance and the Set of {@link TopicPartition}s available on the instance.
  * NOTE: This is a point in time view. It may change when rebalances happen.
- * @deprecated since 3.0.0 use {@link org.apache.kafka.streams.StreamsMetadata}
  */
-@Deprecated
-public class StreamsMetadata {
+public class StreamsMetadataImpl implements StreamsMetadata {
     /**
      * Sentinel to indicate that the StreamsMetadata is currently unavailable. This can occur during rebalance
      * operations.
      */
-    public final static StreamsMetadata NOT_AVAILABLE = new StreamsMetadata(HostInfo.unavailable(),
-                                                                            Collections.emptySet(),
-                                                                            Collections.emptySet(),
-                                                                            Collections.emptySet(),
-                                                                            Collections.emptySet());
+    public final static StreamsMetadataImpl NOT_AVAILABLE = new StreamsMetadataImpl(
+        HostInfo.unavailable(),
+        Collections.emptySet(),
+        Collections.emptySet(),
+        Collections.emptySet(),
+        Collections.emptySet());
 
     private final HostInfo hostInfo;
 
@@ -53,17 +54,17 @@ public class StreamsMetadata {
 
     private final Set<TopicPartition> standbyTopicPartitions;
 
-    public StreamsMetadata(final HostInfo hostInfo,
-                           final Set<String> stateStoreNames,
-                           final Set<TopicPartition> topicPartitions,
-                           final Set<String> standbyStateStoreNames,
-                           final Set<TopicPartition> standbyTopicPartitions) {
+    public StreamsMetadataImpl(final HostInfo hostInfo,
+                               final Set<String> stateStoreNames,
+                               final Set<TopicPartition> topicPartitions,
+                               final Set<String> standbyStateStoreNames,
+                               final Set<TopicPartition> standbyTopicPartitions) {
 
         this.hostInfo = hostInfo;
-        this.stateStoreNames = stateStoreNames;
-        this.topicPartitions = topicPartitions;
-        this.standbyTopicPartitions = standbyTopicPartitions;
-        this.standbyStateStoreNames = standbyStateStoreNames;
+        this.stateStoreNames = Collections.unmodifiableSet(stateStoreNames);
+        this.topicPartitions = Collections.unmodifiableSet(topicPartitions);
+        this.standbyTopicPartitions = Collections.unmodifiableSet(standbyTopicPartitions);
+        this.standbyStateStoreNames = Collections.unmodifiableSet(standbyStateStoreNames);
     }
 
     /**
@@ -72,6 +73,7 @@ public class StreamsMetadata {
      *
      * @return {@link HostInfo} corresponding to the streams instance
      */
+    @Override
     public HostInfo hostInfo() {
         return hostInfo;
     }
@@ -81,8 +83,9 @@ public class StreamsMetadata {
      *
      * @return set of active state store names
      */
+    @Override
     public Set<String> stateStoreNames() {
-        return Collections.unmodifiableSet(stateStoreNames);
+        return stateStoreNames;
     }
 
     /**
@@ -90,8 +93,9 @@ public class StreamsMetadata {
      *
      * @return set of active topic partitions
      */
+    @Override
     public Set<TopicPartition> topicPartitions() {
-        return Collections.unmodifiableSet(topicPartitions);
+        return topicPartitions;
     }
 
     /**
@@ -99,8 +103,9 @@ public class StreamsMetadata {
      *
      * @return set of standby topic partitions
      */
+    @Override
     public Set<TopicPartition> standbyTopicPartitions() {
-        return Collections.unmodifiableSet(standbyTopicPartitions);
+        return standbyTopicPartitions;
     }
 
     /**
@@ -108,15 +113,18 @@ public class StreamsMetadata {
      *
      * @return set of standby state store names
      */
+    @Override
     public Set<String> standbyStateStoreNames() {
-        return Collections.unmodifiableSet(standbyStateStoreNames);
+        return standbyStateStoreNames;
     }
 
+    @Override
     public String host() {
         return hostInfo.host();
     }
 
     @SuppressWarnings("unused")
+    @Override
     public int port() {
         return hostInfo.port();
     }
@@ -130,7 +138,7 @@ public class StreamsMetadata {
             return false;
         }
 
-        final StreamsMetadata that = (StreamsMetadata) o;
+        final StreamsMetadataImpl that = (StreamsMetadataImpl) o;
         return Objects.equals(hostInfo, that.hostInfo)
             && Objects.equals(stateStoreNames, that.stateStoreNames)
             && Objects.equals(topicPartitions, that.topicPartitions)

--- a/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/EosIntegrationTest.java
@@ -696,13 +696,13 @@ public class EosIntegrationTest {
             // the assignment is. We only really care that the remaining instance only sees one host
             // that owns both partitions.
             waitForCondition(
-                () -> stallingInstance.allMetadata().size() == 2
-                    && remainingInstance.allMetadata().size() == 1
-                    && remainingInstance.allMetadata().iterator().next().topicPartitions().size() == 2,
+                () -> stallingInstance.metadataForAllStreamsClients().size() == 2
+                    && remainingInstance.metadataForAllStreamsClients().size() == 1
+                    && remainingInstance.metadataForAllStreamsClients().iterator().next().topicPartitions().size() == 2,
                 MAX_WAIT_TIME_MS,
                 () -> "Should have rebalanced.\n" +
-                    "Streams1[" + streams1.allMetadata() + "]\n" +
-                    "Streams2[" + streams2.allMetadata() + "]");
+                    "Streams1[" + streams1.metadataForAllStreamsClients() + "]\n" +
+                    "Streams2[" + streams2.metadataForAllStreamsClients() + "]");
 
             // expected end state per output partition (C == COMMIT; A == ABORT; ---> indicate the changes):
             //
@@ -729,14 +729,14 @@ public class EosIntegrationTest {
             // It doesn't really matter what the assignment is, but we might as well also assert that they
             // both see both partitions assigned exactly once
             waitForCondition(
-                () -> streams1.allMetadata().size() == 2
-                    && streams2.allMetadata().size() == 2
-                    && streams1.allMetadata().stream().mapToLong(meta -> meta.topicPartitions().size()).sum() == 2
-                    && streams2.allMetadata().stream().mapToLong(meta -> meta.topicPartitions().size()).sum() == 2,
+                () -> streams1.metadataForAllStreamsClients().size() == 2
+                    && streams2.metadataForAllStreamsClients().size() == 2
+                    && streams1.metadataForAllStreamsClients().stream().mapToLong(meta -> meta.topicPartitions().size()).sum() == 2
+                    && streams2.metadataForAllStreamsClients().stream().mapToLong(meta -> meta.topicPartitions().size()).sum() == 2,
                 MAX_WAIT_TIME_MS,
                 () -> "Should have rebalanced.\n" +
-                    "Streams1[" + streams1.allMetadata() + "]\n" +
-                    "Streams2[" + streams2.allMetadata() + "]");
+                    "Streams1[" + streams1.metadataForAllStreamsClients() + "]\n" +
+                    "Streams2[" + streams2.metadataForAllStreamsClients() + "]");
 
             writeInputData(dataAfterSecondRebalance);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinDistributedTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/KTableKTableForeignKeyJoinDistributedTest.java
@@ -27,11 +27,11 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.ValueJoiner;
-import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -214,13 +214,13 @@ public class KTableKTableForeignKeyJoinDistributedTest {
     private void setStateListenersForVerification(final Predicate<ThreadMetadata> taskCondition) {
         client1.setStateListener((newState, oldState) -> {
             if (newState == KafkaStreams.State.RUNNING &&
-                    client1.localThreadsMetadata().stream().allMatch(taskCondition)) {
+                    client1.metadataForLocalThreads().stream().allMatch(taskCondition)) {
                 client1IsOk = true;
             }
         });
         client2.setStateListener((newState, oldState) -> {
             if (newState == KafkaStreams.State.RUNNING &&
-                    client2.localThreadsMetadata().stream().allMatch(taskCondition)) {
+                    client2.metadataForLocalThreads().stream().allMatch(taskCondition)) {
                 client2IsOk = true;
             }
         });

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskCreationIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StandbyTaskCreationIntegrationTest.java
@@ -22,13 +22,13 @@ import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Transformer;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
@@ -167,14 +167,14 @@ public class StandbyTaskCreationIntegrationTest {
     private void setStateListenersForVerification(final Predicate<ThreadMetadata> taskCondition) {
         client1.setStateListener((newState, oldState) -> {
             if (newState == State.RUNNING &&
-                client1.localThreadsMetadata().stream().allMatch(taskCondition)) {
+                client1.metadataForLocalThreads().stream().allMatch(taskCondition)) {
 
                 client1IsOk = true;
             }
         });
         client2.setStateListener((newState, oldState) -> {
             if (newState == State.RUNNING &&
-                client2.localThreadsMetadata().stream().allMatch(taskCondition)) {
+                client2.metadataForLocalThreads().stream().allMatch(taskCondition)) {
 
                 client2IsOk = true;
             }

--- a/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/StoreQueryIntegrationTest.java
@@ -370,8 +370,8 @@ public class StoreQueryIntegrationTest {
 
         startApplicationAndWaitUntilRunning(kafkaStreamsList, Duration.ofSeconds(60));
 
-        assertTrue(kafkaStreams1.localThreadsMetadata().size() > 1);
-        assertTrue(kafkaStreams2.localThreadsMetadata().size() > 1);
+        assertTrue(kafkaStreams1.metadataForLocalThreads().size() > 1);
+        assertTrue(kafkaStreams2.metadataForLocalThreads().size() > 1);
 
         produceValueRange(key, 0, batch1NumMessages);
 

--- a/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/integration/TaskMetadataIntegrationTest.java
@@ -24,10 +24,10 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TaskMetadata;
 import org.apache.kafka.streams.integration.utils.EmbeddedKafkaCluster;
 import org.apache.kafka.streams.integration.utils.IntegrationTestUtils;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.processor.TaskMetadata;
 import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -158,7 +158,7 @@ public class TaskMetadataIntegrationTest {
     }
 
     private TaskMetadata getTaskMetadata(final KafkaStreams kafkaStreams) {
-        final List<TaskMetadata> taskMetadataList = kafkaStreams.localThreadsMetadata().stream().flatMap(t -> t.activeTasks().stream()).collect(Collectors.toList());
+        final List<TaskMetadata> taskMetadataList = kafkaStreams.metadataForLocalThreads().stream().flatMap(t -> t.activeTasks().stream()).collect(Collectors.toList());
         assertThat("only one task", taskMetadataList.size() == 1);
         return taskMetadataList.get(0);
     }

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamThreadTest.java
@@ -52,6 +52,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskCorruptedException;
@@ -63,8 +64,6 @@ import org.apache.kafka.streams.kstream.internals.MaterializedInternal;
 import org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.PunctuationType;
 import org.apache.kafka.streams.processor.TaskId;
-import org.apache.kafka.streams.processor.TaskMetadata;
-import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.processor.api.ProcessorSupplier;
 import org.apache.kafka.streams.processor.internals.assignment.ReferenceContainer;
 import org.apache.kafka.streams.processor.internals.metrics.StreamsMetricsImpl;
@@ -1115,6 +1114,7 @@ public class StreamThreadTest {
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumerGroupMetadata);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         taskManager.shutdown(true);
         EasyMock.expectLastCall();
         EasyMock.replay(taskManager, consumer);
@@ -1153,7 +1153,7 @@ public class StreamThreadTest {
     @Test
     public void shouldNotReturnDataAfterTaskMigrated() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final InternalTopologyBuilder internalTopologyBuilder = EasyMock.createNiceMock(InternalTopologyBuilder.class);
 
         expect(internalTopologyBuilder.sourceTopicCollection()).andReturn(Collections.singletonList(topic1)).times(2);
@@ -1221,6 +1221,7 @@ public class StreamThreadTest {
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumerGroupMetadata);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         taskManager.shutdown(true);
         EasyMock.expectLastCall();
         EasyMock.replay(taskManager, consumer);
@@ -1258,6 +1259,7 @@ public class StreamThreadTest {
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumerGroupMetadata);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         taskManager.shutdown(true);
         EasyMock.expectLastCall();
         EasyMock.replay(taskManager, consumer);
@@ -1641,7 +1643,7 @@ public class StreamThreadTest {
 
         final ThreadMetadata metadata = thread.threadMetadata();
         assertEquals(StreamThread.State.RUNNING.name(), metadata.threadState());
-        assertTrue(metadata.activeTasks().contains(new TaskMetadata(task1, Utils.mkSet(t1p1), new HashMap<>(), new HashMap<>(), Optional.empty())));
+        assertTrue(metadata.activeTasks().contains(new TaskMetadataImpl(task1, Utils.mkSet(t1p1), new HashMap<>(), new HashMap<>(), Optional.empty())));
         assertTrue(metadata.standbyTasks().isEmpty());
 
         assertTrue("#threadState() was: " + metadata.threadState() + "; expected either RUNNING, STARTING, PARTITIONS_REVOKED, PARTITIONS_ASSIGNED, or CREATED",
@@ -1694,7 +1696,7 @@ public class StreamThreadTest {
 
         final ThreadMetadata threadMetadata = thread.threadMetadata();
         assertEquals(StreamThread.State.RUNNING.name(), threadMetadata.threadState());
-        assertTrue(threadMetadata.standbyTasks().contains(new TaskMetadata(task1, Utils.mkSet(t1p1), new HashMap<>(), new HashMap<>(), Optional.empty())));
+        assertTrue(threadMetadata.standbyTasks().contains(new TaskMetadataImpl(task1, Utils.mkSet(t1p1), new HashMap<>(), new HashMap<>(), Optional.empty())));
         assertTrue(threadMetadata.activeTasks().isEmpty());
 
         thread.taskManager().shutdown(true);
@@ -1974,12 +1976,6 @@ public class StreamThreadTest {
         assertEquals(StreamThread.State.RUNNING.name(), metadata.threadState());
     }
 
-    private void assertThreadMetadataHasEmptyTasksWithState(final ThreadMetadata metadata, final StreamThread.State state) {
-        assertEquals(state.name(), metadata.threadState());
-        assertTrue(metadata.activeTasks().isEmpty());
-        assertTrue(metadata.standbyTasks().isEmpty());
-    }
-
     @Test
     public void shouldRecoverFromInvalidOffsetExceptionOnRestoreAndFinishRestore() throws Exception {
         internalStreamsBuilder.stream(Collections.singleton("topic"), consumed)
@@ -2163,6 +2159,7 @@ public class StreamThreadTest {
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         consumer.assign(assignedPartitions);
         consumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
@@ -2210,6 +2207,7 @@ public class StreamThreadTest {
         final Set<TopicPartition> assignedPartitions = Collections.singleton(t1p1);
 
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
         consumer.assign(assignedPartitions);
         consumer.updateBeginningOffsets(Collections.singletonMap(t1p1, 0L));
@@ -2256,7 +2254,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchHandleCorruptionOnTaskCorruptedExceptionPath() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
-
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         consumer.subscribe((Collection<String>) anyObject(), anyObject());
@@ -2319,6 +2317,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchTimeoutExceptionFromHandleCorruptionAndInvokeExceptionHandler() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -2386,6 +2385,7 @@ public class StreamThreadTest {
     @SuppressWarnings("unchecked")
     public void shouldCatchTaskMigratedExceptionOnOnTaskCorruptedExceptionPath() {
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final Consumer<byte[], byte[]> consumer = mock(Consumer.class);
         final ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
         expect(consumer.groupMetadata()).andStubReturn(consumerGroupMetadata);
@@ -2718,6 +2718,7 @@ public class StreamThreadTest {
         expect(consumerGroupMetadata.groupInstanceId()).andReturn(Optional.empty());
         EasyMock.replay(consumer, consumerGroupMetadata);
         final TaskManager taskManager = EasyMock.createNiceMock(TaskManager.class);
+        expect(taskManager.producerClientIds()).andStubReturn(Collections.emptySet());
         final StreamsMetricsImpl streamsMetrics =
             new StreamsMetricsImpl(metrics, CLIENT_ID, StreamsConfig.METRICS_LATEST, mockTime);
         final StreamThread thread = new StreamThread(

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/StreamsMetadataStateTest.java
@@ -24,13 +24,14 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KeyQueryMetadata;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsMetadata;
 import org.apache.kafka.streams.TopologyWrapper;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.state.HostInfo;
-import org.apache.kafka.streams.state.StreamsMetadata;
+import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -139,17 +140,17 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldGetAllStreamInstances() {
-        final StreamsMetadata one = new StreamsMetadata(hostOne,
+        final StreamsMetadata one = new StreamsMetadataImpl(hostOne,
             mkSet(globalTable, "table-one", "table-two", "merged-table"),
             mkSet(topic1P0, topic2P1, topic4P0),
             mkSet("table-one", "table-two", "merged-table"),
             mkSet(topic2P0, topic1P1));
-        final StreamsMetadata two = new StreamsMetadata(hostTwo,
+        final StreamsMetadata two = new StreamsMetadataImpl(hostTwo,
             mkSet(globalTable, "table-two", "table-one", "merged-table"),
             mkSet(topic2P0, topic1P1),
             mkSet("table-three"),
             mkSet(topic3P0));
-        final StreamsMetadata three = new StreamsMetadata(hostThree,
+        final StreamsMetadata three = new StreamsMetadataImpl(hostThree,
             mkSet(globalTable, "table-three"),
             Collections.singleton(topic3P0),
             mkSet("table-one", "table-two", "merged-table"),
@@ -173,7 +174,7 @@ public class StreamsMetadataStateTest {
         metadataState.onChange(hostToActivePartitions, Collections.emptyMap(),
             cluster.withPartitions(Collections.singletonMap(tp5, new PartitionInfo("topic-five", 1, null, null, null))));
 
-        final StreamsMetadata expected = new StreamsMetadata(hostFour, Collections.singleton(globalTable),
+        final StreamsMetadata expected = new StreamsMetadataImpl(hostFour, Collections.singleton(globalTable),
                 Collections.singleton(tp5), Collections.emptySet(), Collections.emptySet());
         final Collection<StreamsMetadata> actual = metadataState.getAllMetadata();
         assertTrue("expected " + actual + " to contain " + expected, actual.contains(expected));
@@ -181,12 +182,12 @@ public class StreamsMetadataStateTest {
 
     @Test
     public void shouldGetInstancesForStoreName() {
-        final StreamsMetadata one = new StreamsMetadata(hostOne,
+        final StreamsMetadata one = new StreamsMetadataImpl(hostOne,
             mkSet(globalTable, "table-one", "table-two", "merged-table"),
             mkSet(topic1P0, topic2P1, topic4P0),
             mkSet("table-one", "table-two", "merged-table"),
             mkSet(topic2P0, topic1P1));
-        final StreamsMetadata two = new StreamsMetadata(hostTwo,
+        final StreamsMetadata two = new StreamsMetadataImpl(hostTwo,
             mkSet(globalTable, "table-two", "table-one", "merged-table"),
             mkSet(topic2P0, topic1P1),
             mkSet("table-three"),

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskMetadataImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/TaskMetadataImplTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.TaskMetadata;
+import org.apache.kafka.streams.processor.TaskId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class TaskMetadataImplTest {
+
+    public static final TaskId TASK_ID = new TaskId(1, 2);
+    public static final TopicPartition TP_0 = new TopicPartition("t", 0);
+    public static final TopicPartition TP_1 = new TopicPartition("t", 1);
+    public static final Set<TopicPartition> TOPIC_PARTITIONS = mkSet(TP_0, TP_1);
+    public static final Map<TopicPartition, Long> COMMITTED_OFFSETS = mkMap(mkEntry(TP_1, 1L), mkEntry(TP_1, 2L));
+    public static final Map<TopicPartition, Long> END_OFFSETS = mkMap(mkEntry(TP_1, 1L), mkEntry(TP_1, 3L));
+    public static final Optional<Long> TIME_CURRENT_IDLING_STARTED = Optional.of(3L);
+
+    private TaskMetadata taskMetadata;
+
+    @Before
+    public void setUp() {
+        taskMetadata = new TaskMetadataImpl(
+            TASK_ID,
+            TOPIC_PARTITIONS,
+            COMMITTED_OFFSETS,
+            END_OFFSETS,
+            TIME_CURRENT_IDLING_STARTED);
+    }
+
+    @Test
+    public void shouldNotAllowModificationOfInternalStateViaGetters() {
+        assertThat(isUnmodifiable(taskMetadata.topicPartitions()), is(true));
+        assertThat(isUnmodifiable(taskMetadata.committedOffsets()), is(true));
+        assertThat(isUnmodifiable(taskMetadata.endOffsets()), is(true));
+    }
+
+    @Test
+    public void shouldBeEqualsIfSameObject() {
+        final TaskMetadataImpl same = new TaskMetadataImpl(
+            TASK_ID,
+            TOPIC_PARTITIONS,
+            COMMITTED_OFFSETS,
+            END_OFFSETS,
+            TIME_CURRENT_IDLING_STARTED);
+        assertThat(taskMetadata, equalTo(same));
+        assertThat(taskMetadata.hashCode(), equalTo(same.hashCode()));
+    }
+
+    @Test
+    public void shouldBeEqualsIfOnlyDifferInCommittedOffsets() {
+        final TaskMetadataImpl stillSameDifferCommittedOffsets = new TaskMetadataImpl(
+            TASK_ID,
+            TOPIC_PARTITIONS,
+            mkMap(mkEntry(TP_1, 1000000L), mkEntry(TP_1, 2L)),
+            END_OFFSETS,
+            TIME_CURRENT_IDLING_STARTED);
+        assertThat(taskMetadata, equalTo(stillSameDifferCommittedOffsets));
+        assertThat(taskMetadata.hashCode(), equalTo(stillSameDifferCommittedOffsets.hashCode()));
+    }
+
+    @Test
+    public void shouldBeEqualsIfOnlyDifferInEndOffsets() {
+        final TaskMetadataImpl stillSameDifferEndOffsets = new TaskMetadataImpl(
+            TASK_ID,
+            TOPIC_PARTITIONS,
+            COMMITTED_OFFSETS,
+            mkMap(mkEntry(TP_1, 1000000L), mkEntry(TP_1, 2L)),
+            TIME_CURRENT_IDLING_STARTED);
+        assertThat(taskMetadata, equalTo(stillSameDifferEndOffsets));
+        assertThat(taskMetadata.hashCode(), equalTo(stillSameDifferEndOffsets.hashCode()));
+    }
+
+    @Test
+    public void shouldBeEqualsIfOnlyDifferInIdlingTime() {
+        final TaskMetadataImpl stillSameDifferIdlingTime = new TaskMetadataImpl(
+            TASK_ID,
+            TOPIC_PARTITIONS,
+            COMMITTED_OFFSETS,
+            END_OFFSETS,
+            Optional.empty());
+        assertThat(taskMetadata, equalTo(stillSameDifferIdlingTime));
+        assertThat(taskMetadata.hashCode(), equalTo(stillSameDifferIdlingTime.hashCode()));
+    }
+
+    @Test
+    public void shouldNotBeEqualsIfDifferInTaskID() {
+        final TaskMetadataImpl differTaskId = new TaskMetadataImpl(
+            new TaskId(1, 10000),
+            TOPIC_PARTITIONS,
+            COMMITTED_OFFSETS,
+            END_OFFSETS,
+            TIME_CURRENT_IDLING_STARTED);
+        assertThat(taskMetadata, not(equalTo(differTaskId)));
+        assertThat(taskMetadata.hashCode(), not(equalTo(differTaskId.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualsIfDifferInTopicPartitions() {
+        final TaskMetadataImpl differTopicPartitions = new TaskMetadataImpl(
+            TASK_ID,
+            mkSet(TP_0),
+            COMMITTED_OFFSETS,
+            END_OFFSETS,
+            TIME_CURRENT_IDLING_STARTED);
+        assertThat(taskMetadata, not(equalTo(differTopicPartitions)));
+        assertThat(taskMetadata.hashCode(), not(equalTo(differTopicPartitions.hashCode())));
+    }
+
+    private static boolean isUnmodifiable(final Collection<?> collection) {
+        try {
+            collection.clear();
+            return false;
+        } catch (final UnsupportedOperationException e) {
+            return true;
+        }
+    }
+
+    private static boolean isUnmodifiable(final Map<?, ?> collection) {
+        try {
+            collection.clear();
+            return false;
+        } catch (final UnsupportedOperationException e) {
+            return true;
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImplTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/processor/internals/ThreadMetadataImplTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.streams.processor.internals;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.TaskMetadata;
+import org.apache.kafka.streams.ThreadMetadata;
+import org.apache.kafka.streams.processor.TaskId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.kafka.common.utils.Utils.mkEntry;
+import static org.apache.kafka.common.utils.Utils.mkMap;
+import static org.apache.kafka.common.utils.Utils.mkSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class ThreadMetadataImplTest {
+
+    public static final String THREAD_NAME = "thread name";
+    public static final String THREAD_STATE = "thread state";
+    public static final String MAIN_CONSUMER_CLIENT_ID = "main Consumer ClientID";
+    public static final String RESTORE_CONSUMER_CLIENT_ID = "restore Consumer ClientID";
+    public static final String CLIENT_ID_1 = "client Id 1";
+    public static final String CLIENT_ID_2 = "client Id 2";
+    public static final Set<String> PRODUCER_CLIENT_IDS = mkSet(CLIENT_ID_1, CLIENT_ID_2);
+    public static final TaskId TASK_ID_0 = new TaskId(1, 2);
+    public static final TaskId TASK_ID_1 = new TaskId(1, 1);
+    public static final TopicPartition TP_0_0 = new TopicPartition("t", 0);
+    public static final TopicPartition TP_1_0 = new TopicPartition("t", 1);
+    public static final TopicPartition TP_0_1 = new TopicPartition("t", 2);
+    public static final TopicPartition TP_1_1 = new TopicPartition("t", 3);
+    public static final TaskMetadata TM_0 = new TaskMetadataImpl(
+        TASK_ID_0,
+        mkSet(TP_0_0, TP_1_0),
+        mkMap(mkEntry(TP_0_0, 1L), mkEntry(TP_1_0, 2L)),
+        mkMap(mkEntry(TP_0_0, 1L), mkEntry(TP_1_0, 2L)),
+        Optional.of(3L));
+    public static final TaskMetadata TM_1 = new TaskMetadataImpl(
+        TASK_ID_1,
+        mkSet(TP_0_1, TP_1_1),
+        mkMap(mkEntry(TP_0_1, 1L), mkEntry(TP_1_1, 2L)),
+        mkMap(mkEntry(TP_0_1, 1L), mkEntry(TP_1_1, 2L)),
+        Optional.of(3L));
+    public static final Set<TaskMetadata> STANDBY_TASKS = mkSet(TM_0, TM_1);
+    public static final Set<TaskMetadata> ACTIVE_TASKS = mkSet(TM_1);
+    public static final String ADMIN_CLIENT_ID = "admin ClientID";
+
+    private ThreadMetadata threadMetadata;
+
+    @Before
+    public void setUp() {
+        threadMetadata = new ThreadMetadataImpl(
+            THREAD_NAME,
+            THREAD_STATE,
+            MAIN_CONSUMER_CLIENT_ID,
+            RESTORE_CONSUMER_CLIENT_ID,
+            PRODUCER_CLIENT_IDS,
+            ADMIN_CLIENT_ID,
+            ACTIVE_TASKS,
+            STANDBY_TASKS
+        );
+    }
+
+    @Test
+    public void shouldNotAllowModificationOfInternalStateViaGetters() {
+        assertThat(isUnmodifiable(threadMetadata.producerClientIds()), is(true));
+        assertThat(isUnmodifiable(threadMetadata.activeTasks()), is(true));
+        assertThat(isUnmodifiable(threadMetadata.standbyTasks()), is(true));
+    }
+
+    @Test
+    public void shouldBeEqualIfSameObject() {
+        final ThreadMetadata same = new ThreadMetadataImpl(
+            THREAD_NAME,
+            THREAD_STATE,
+            MAIN_CONSUMER_CLIENT_ID,
+            RESTORE_CONSUMER_CLIENT_ID,
+            PRODUCER_CLIENT_IDS,
+            ADMIN_CLIENT_ID,
+            ACTIVE_TASKS,
+            STANDBY_TASKS
+        );
+        assertThat(threadMetadata, equalTo(same));
+        assertThat(threadMetadata.hashCode(), equalTo(same.hashCode()));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInThreadName() {
+        final ThreadMetadata differThreadName = new ThreadMetadataImpl(
+            "different",
+            THREAD_STATE,
+            MAIN_CONSUMER_CLIENT_ID,
+            RESTORE_CONSUMER_CLIENT_ID,
+            PRODUCER_CLIENT_IDS,
+            ADMIN_CLIENT_ID,
+            ACTIVE_TASKS,
+            STANDBY_TASKS
+        );
+        assertThat(threadMetadata, not(equalTo(differThreadName)));
+        assertThat(threadMetadata.hashCode(), not(equalTo(differThreadName.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInThreadState() {
+        final ThreadMetadata differThreadState = new ThreadMetadataImpl(
+            THREAD_NAME,
+            "different",
+            MAIN_CONSUMER_CLIENT_ID,
+            RESTORE_CONSUMER_CLIENT_ID,
+            PRODUCER_CLIENT_IDS,
+            ADMIN_CLIENT_ID,
+            ACTIVE_TASKS,
+            STANDBY_TASKS
+        );
+        assertThat(threadMetadata, not(equalTo(differThreadState)));
+        assertThat(threadMetadata.hashCode(), not(equalTo(differThreadState.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInClientId() {
+        final ThreadMetadata differMainConsumerClientId = new ThreadMetadataImpl(
+            THREAD_NAME,
+            THREAD_STATE,
+            "different",
+            RESTORE_CONSUMER_CLIENT_ID,
+            PRODUCER_CLIENT_IDS,
+            ADMIN_CLIENT_ID,
+            ACTIVE_TASKS,
+            STANDBY_TASKS
+        );
+        assertThat(threadMetadata, not(equalTo(differMainConsumerClientId)));
+        assertThat(threadMetadata.hashCode(), not(equalTo(differMainConsumerClientId.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInConsumerClientId() {
+        final ThreadMetadata differRestoreConsumerClientId = new ThreadMetadataImpl(
+            THREAD_NAME,
+            THREAD_STATE,
+            MAIN_CONSUMER_CLIENT_ID,
+            "different",
+            PRODUCER_CLIENT_IDS,
+            ADMIN_CLIENT_ID,
+            ACTIVE_TASKS,
+            STANDBY_TASKS
+        );
+        assertThat(threadMetadata, not(equalTo(differRestoreConsumerClientId)));
+        assertThat(threadMetadata.hashCode(), not(equalTo(differRestoreConsumerClientId.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInProducerClientIds() {
+        final ThreadMetadata differProducerClientIds = new ThreadMetadataImpl(
+            THREAD_NAME,
+            THREAD_STATE,
+            MAIN_CONSUMER_CLIENT_ID,
+            RESTORE_CONSUMER_CLIENT_ID,
+            mkSet(CLIENT_ID_1),
+            ADMIN_CLIENT_ID,
+            ACTIVE_TASKS,
+            STANDBY_TASKS
+        );
+        assertThat(threadMetadata, not(equalTo(differProducerClientIds)));
+        assertThat(threadMetadata.hashCode(), not(equalTo(differProducerClientIds.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInAdminClientId() {
+        final ThreadMetadata differAdminClientId = new ThreadMetadataImpl(
+            THREAD_NAME,
+            THREAD_STATE,
+            MAIN_CONSUMER_CLIENT_ID,
+            RESTORE_CONSUMER_CLIENT_ID,
+            PRODUCER_CLIENT_IDS,
+            "different",
+            ACTIVE_TASKS,
+            STANDBY_TASKS
+        );
+        assertThat(threadMetadata, not(equalTo(differAdminClientId)));
+        assertThat(threadMetadata.hashCode(), not(equalTo(differAdminClientId.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInActiveTasks() {
+        final ThreadMetadata differActiveTasks = new ThreadMetadataImpl(
+            THREAD_NAME,
+            THREAD_STATE,
+            MAIN_CONSUMER_CLIENT_ID,
+            RESTORE_CONSUMER_CLIENT_ID,
+            PRODUCER_CLIENT_IDS,
+            ADMIN_CLIENT_ID,
+            mkSet(TM_0),
+            STANDBY_TASKS
+        );
+        assertThat(threadMetadata, not(equalTo(differActiveTasks)));
+        assertThat(threadMetadata.hashCode(), not(equalTo(differActiveTasks.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInStandByTasks() {
+        final ThreadMetadata differStandByTasks = new ThreadMetadataImpl(
+            THREAD_NAME,
+            THREAD_STATE,
+            MAIN_CONSUMER_CLIENT_ID,
+            RESTORE_CONSUMER_CLIENT_ID,
+            PRODUCER_CLIENT_IDS,
+            ADMIN_CLIENT_ID,
+            ACTIVE_TASKS,
+            mkSet(TM_0)
+        );
+        assertThat(threadMetadata, not(equalTo(differStandByTasks)));
+        assertThat(threadMetadata.hashCode(), not(equalTo(differStandByTasks.hashCode())));
+    }
+
+    private static boolean isUnmodifiable(final Collection<?> collection) {
+        try {
+            collection.clear();
+            return false;
+        } catch (final UnsupportedOperationException e) {
+            return true;
+        }
+    }
+}

--- a/streams/src/test/java/org/apache/kafka/streams/state/StreamsMetadataTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/state/StreamsMetadataTest.java
@@ -18,39 +18,121 @@
 package org.apache.kafka.streams.state;
 
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.StreamsMetadata;
+import org.apache.kafka.streams.state.internals.StreamsMetadataImpl;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.Set;
 
 import static org.apache.kafka.common.utils.Utils.mkSet;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 public class StreamsMetadataTest {
 
     private static final HostInfo HOST_INFO = new HostInfo("local", 12);
+    public static final Set<String> STATE_STORE_NAMES = mkSet("store1", "store2");
     private static final TopicPartition TP_0 = new TopicPartition("t", 0);
     private static final TopicPartition TP_1 = new TopicPartition("t", 1);
+    public static final Set<TopicPartition> TOPIC_PARTITIONS = mkSet(TP_0, TP_1);
+    public static final Set<String> STAND_BY_STORE_NAMES = mkSet("store2");
+    public static final Set<TopicPartition> STANDBY_TOPIC_PARTITIONS = mkSet(TP_1);
 
     private StreamsMetadata streamsMetadata;
 
     @Before
     public void setUp() {
-        streamsMetadata = new StreamsMetadata(
+        streamsMetadata = new StreamsMetadataImpl(
             HOST_INFO,
-            mkSet("store1", "store2"),
-            mkSet(TP_0, TP_1),
-            mkSet("store2"),
-            mkSet(TP_1)
+            STATE_STORE_NAMES,
+            TOPIC_PARTITIONS,
+            STAND_BY_STORE_NAMES,
+            STANDBY_TOPIC_PARTITIONS
         );
     }
 
     @Test
     public void shouldNotAllowModificationOfInternalStateViaGetters() {
-        assertTrue(isUnmodifiable(streamsMetadata.stateStoreNames()));
-        assertTrue(isUnmodifiable(streamsMetadata.topicPartitions()));
-        assertTrue(isUnmodifiable(streamsMetadata.standbyTopicPartitions()));
-        assertTrue(isUnmodifiable(streamsMetadata.standbyStateStoreNames()));
+        assertThat(isUnmodifiable(streamsMetadata.stateStoreNames()), is(true));
+        assertThat(isUnmodifiable(streamsMetadata.topicPartitions()), is(true));
+        assertThat(isUnmodifiable(streamsMetadata.standbyTopicPartitions()), is(true));
+        assertThat(isUnmodifiable(streamsMetadata.standbyStateStoreNames()), is(true));
+    }
+
+    @Test
+    public void shouldBeEqualsIfSameObject() {
+        final StreamsMetadata same = new StreamsMetadataImpl(
+            HOST_INFO,
+            STATE_STORE_NAMES,
+            TOPIC_PARTITIONS,
+            STAND_BY_STORE_NAMES,
+            STANDBY_TOPIC_PARTITIONS);
+        assertThat(streamsMetadata, equalTo(same));
+        assertThat(streamsMetadata.hashCode(), equalTo(same.hashCode()));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInHostInfo() {
+        final StreamsMetadata differHostInfo = new StreamsMetadataImpl(
+            new HostInfo("different", 122),
+            STATE_STORE_NAMES,
+            TOPIC_PARTITIONS,
+            STAND_BY_STORE_NAMES,
+            STANDBY_TOPIC_PARTITIONS);
+        assertThat(streamsMetadata, not(equalTo(differHostInfo)));
+        assertThat(streamsMetadata.hashCode(), not(equalTo(differHostInfo.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferStateStoreNames() {
+        final StreamsMetadata differStateStoreNames = new StreamsMetadataImpl(
+            HOST_INFO,
+            mkSet("store1"),
+            TOPIC_PARTITIONS,
+            STAND_BY_STORE_NAMES,
+            STANDBY_TOPIC_PARTITIONS);
+        assertThat(streamsMetadata, not(equalTo(differStateStoreNames)));
+        assertThat(streamsMetadata.hashCode(), not(equalTo(differStateStoreNames.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInTopicPartitions() {
+        final StreamsMetadata differTopicPartitions = new StreamsMetadataImpl(
+            HOST_INFO,
+            STATE_STORE_NAMES,
+            mkSet(TP_0),
+            STAND_BY_STORE_NAMES,
+            STANDBY_TOPIC_PARTITIONS);
+        assertThat(streamsMetadata, not(equalTo(differTopicPartitions)));
+        assertThat(streamsMetadata.hashCode(), not(equalTo(differTopicPartitions.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInStandByStores() {
+        final StreamsMetadata differStandByStores = new StreamsMetadataImpl(
+            HOST_INFO,
+            STATE_STORE_NAMES,
+            TOPIC_PARTITIONS,
+            mkSet("store1"),
+            STANDBY_TOPIC_PARTITIONS);
+        assertThat(streamsMetadata, not(equalTo(differStandByStores)));
+        assertThat(streamsMetadata.hashCode(), not(equalTo(differStandByStores.hashCode())));
+    }
+
+    @Test
+    public void shouldNotBeEqualIfDifferInStandByTopicPartitions() {
+        final StreamsMetadata differStandByTopicPartitions = new StreamsMetadataImpl(
+            HOST_INFO,
+            STATE_STORE_NAMES,
+            TOPIC_PARTITIONS,
+            STAND_BY_STORE_NAMES,
+            mkSet(TP_0));
+        assertThat(streamsMetadata, not(equalTo(differStandByTopicPartitions)));
+        assertThat(streamsMetadata.hashCode(), not(equalTo(differStandByTopicPartitions.hashCode())));
     }
 
     private static boolean isUnmodifiable(final Collection<?> collection) {

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStandByReplicaTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsStandByReplicaTest.java
@@ -26,13 +26,13 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.ValueMapper;
-import org.apache.kafka.streams.processor.ThreadMetadata;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.Stores;
 
@@ -137,7 +137,7 @@ public class StreamsStandByReplicaTest {
 
         streams.setStateListener((newState, oldState) -> {
             if (newState == KafkaStreams.State.RUNNING && oldState == KafkaStreams.State.REBALANCING) {
-                final Set<ThreadMetadata> threadMetadata = streams.localThreadsMetadata();
+                final Set<ThreadMetadata> threadMetadata = streams.metadataForLocalThreads();
                 for (final ThreadMetadata threadMetadatum : threadMetadata) {
                     System.out.println(
                         "ACTIVE_TASKS:" + threadMetadatum.activeTasks().size()

--- a/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
+++ b/streams/src/test/java/org/apache/kafka/streams/tests/StreamsUpgradeToCooperativeRebalanceTest.java
@@ -24,9 +24,9 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TaskMetadata;
+import org.apache.kafka.streams.ThreadMetadata;
 import org.apache.kafka.streams.kstream.ForeachAction;
-import org.apache.kafka.streams.processor.TaskMetadata;
-import org.apache.kafka.streams.processor.ThreadMetadata;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,7 +82,7 @@ public class StreamsUpgradeToCooperativeRebalanceTest {
         streams.setStateListener((newState, oldState) -> {
             if (newState == State.RUNNING && oldState == State.REBALANCING) {
                 System.out.println(String.format("%sSTREAMS in a RUNNING State", upgradePhase));
-                final Set<ThreadMetadata> allThreadMetadata = streams.localThreadsMetadata();
+                final Set<ThreadMetadata> allThreadMetadata = streams.metadataForLocalThreads();
                 final StringBuilder taskReportBuilder = new StringBuilder();
                 final List<String> activeTasks = new ArrayList<>();
                 final List<String> standbyTasks = new ArrayList<>();
@@ -110,7 +110,7 @@ public class StreamsUpgradeToCooperativeRebalanceTest {
 
         Exit.addShutdownHook("streams-shutdown-hook", () -> {
             streams.close();
-            System.out.println(String.format("%sCOOPERATIVE-REBALANCE-TEST-CLIENT-CLOSED", upgradePhase));
+            System.out.printf("%sCOOPERATIVE-REBALANCE-TEST-CLIENT-CLOSED%n", upgradePhase);
             System.out.flush();
         });
     }

--- a/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
+++ b/streams/streams-scala/src/test/scala/org/apache/kafka/streams/scala/kstream/KStreamTest.scala
@@ -18,6 +18,7 @@ package org.apache.kafka.streams.scala.kstream
 
 import java.time.Duration.ofSeconds
 import java.time.Instant
+import java.util.regex.Pattern
 
 import org.apache.kafka.streams.KeyValue
 import org.apache.kafka.streams.kstream.{
@@ -463,4 +464,23 @@ class KStreamTest extends TestDriver {
     val transformNode = builder.build().describe().subtopologies().asScala.head.nodes().asScala.toList(1)
     assertEquals("my-name", transformNode.name())
   }
+
+  @Test
+  def testSettingNameOnStream(): Unit = {
+    val builder = new StreamsBuilder()
+    val topicsPattern = "t-[A-Za-z0-9-].suffix"
+    val sinkTopic = "sink"
+
+    builder
+      .stream[String, String](Pattern.compile(topicsPattern))(
+        Consumed.`with`[String, String].withName("my-fancy-name")
+      )
+      .to(sinkTopic)
+
+    import scala.jdk.CollectionConverters._
+
+    val streamNode = builder.build().describe().subtopologies().asScala.head.nodes().asScala.head
+    assertEquals("my-fancy-name", streamNode.name())
+  }
+
 }


### PR DESCRIPTION
Jira issue (detailed description): https://issues.apache.org/jira/browse/KAFKA-12999

## Summary

After upgrading clients to `2.8.0`, reading `ConsumerRecord`'s header keys started resulting in occasional `java.lang.NullPointerException` in case of concurrent access from multiple(2) threads.

### NPE location

NPE happens here [RecordHeader.java:45](https://github.com/apache/kafka/blob/2.8.0/clients/src/main/java/org/apache/kafka/common/header/internals/RecordHeader.java#L45):
```java
public String key() {
    if (key == null) {
        key = Utils.utf8(keyBuffer, keyBuffer.remaining()); // NPE here 
        keyBuffer = null;
    }
    return key;
}
```

### What introduced issue 
Cause of issue is introduced by changes of #9223

### Consequences
Current implementation renders RecordHeader not thread-safe for read-only access.

### Reproducibility
Since issue s concurrent race condition, reproducibility is non-deterministic but easy to reproduce with enough re-attempts
This PR has test which almost always reproduces issue (wiithout `synchronized`)

### Fix strategy
This PR avoids race-condition by having `synchronized` on `key()` and `value()` methods

### Benchmark
Comparison between with and without `synchronized` on `RecordHeader.key()` method
```
Benchmark                              Mode  Cnt   Score   Error  Units
RecordHeaderBenchmark.key              avgt    15  31.308 ± 7.862  ns/op
RecordHeaderBenchmark.synchronizedKey  avgt    15  31.853 ± 7.096  ns/op
```

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
